### PR TITLE
修复委派任务的权限策略继承

### DIFF
--- a/core/src/agent_api/agent_binding.rs
+++ b/core/src/agent_api/agent_binding.rs
@@ -27,7 +27,7 @@ fn apply_permissions(opts: &mut SessionOptions, def: &AgentDefinition) {
 }
 
 fn has_defined_permissions(def: &AgentDefinition) -> bool {
-    !def.permissions.allow.is_empty() || !def.permissions.deny.is_empty()
+    !def.permissions.is_default_policy()
 }
 
 fn apply_step_budget(opts: &mut SessionOptions, def: &AgentDefinition) {
@@ -128,5 +128,26 @@ mod tests {
         let opts = apply_agent_definition(SessionOptions::new(), &def);
 
         assert_eq!(opts.model.as_deref(), Some("anthropic/claude-opus"));
+    }
+
+    #[test]
+    fn applies_default_allow_agent_permissions() {
+        use crate::permissions::PermissionDecision;
+
+        let permissions = PermissionPolicy {
+            default_decision: PermissionDecision::Allow,
+            ..PermissionPolicy::new()
+        };
+        let def = AgentDefinition::new("worker", "Allowed worker").with_permissions(permissions);
+
+        let opts = apply_agent_definition(SessionOptions::new(), &def);
+
+        let checker = opts
+            .permission_checker
+            .expect("non-default permission policy should be applied");
+        assert_eq!(
+            checker.check("bash", &serde_json::json!({"command": "echo ok"})),
+            PermissionDecision::Allow
+        );
     }
 }

--- a/core/src/permissions/policy.rs
+++ b/core/src/permissions/policy.rs
@@ -9,7 +9,7 @@ use super::{MatchingRules, PermissionChecker, PermissionDecision, PermissionRule
 /// 2. Allow rules - any match results in auto-approval
 /// 3. Ask rules - any match requires user confirmation
 /// 4. Default - falls back to default_decision
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PermissionPolicy {
     /// Rules that always deny (checked first)
     #[serde(default)]
@@ -56,6 +56,11 @@ impl PermissionPolicy {
     /// Create a new permission policy
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Return true when this policy is still the implicit default Ask policy.
+    pub fn is_default_policy(&self) -> bool {
+        self == &Self::default()
     }
 
     /// Create a strict policy that asks for everything

--- a/core/src/tools/task.rs
+++ b/core/src/tools/task.rs
@@ -15,9 +15,10 @@
 //! ```
 
 use crate::agent::{AgentConfig, AgentEvent, AgentLoop};
-use crate::llm::LlmClient;
+use crate::llm::{LlmClient, ToolDefinition};
 use crate::mcp::manager::McpManager;
-use crate::subagent::AgentRegistry;
+use crate::permissions::PermissionChecker;
+use crate::subagent::{AgentDefinition, AgentRegistry};
 use crate::tools::types::{Tool, ToolContext, ToolOutput};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -128,6 +129,39 @@ fn format_task_result_for_context(result: &TaskResult) -> (String, bool) {
     (formatted, truncated)
 }
 
+fn has_defined_permissions(agent: &AgentDefinition) -> bool {
+    !agent.permissions.is_default_policy()
+}
+
+fn agent_permission_checker(agent: &AgentDefinition) -> Option<Arc<dyn PermissionChecker>> {
+    if has_defined_permissions(agent) {
+        Some(Arc::new(agent.permissions.clone()) as Arc<dyn PermissionChecker>)
+    } else {
+        None
+    }
+}
+
+fn build_child_config(
+    agent: &AgentDefinition,
+    params: &TaskParams,
+    tools: Vec<ToolDefinition>,
+) -> AgentConfig {
+    let mut prompt_slots = crate::prompts::SystemPromptSlots::default();
+    if let Some(ref p) = agent.prompt {
+        prompt_slots.extra = Some(p.clone());
+    }
+
+    AgentConfig {
+        prompt_slots,
+        tools,
+        max_tool_rounds: params
+            .max_steps
+            .unwrap_or_else(|| agent.max_steps.unwrap_or(20)),
+        permission_checker: agent_permission_checker(agent),
+        ..AgentConfig::default()
+    }
+}
+
 /// Task executor for delegated child runs.
 pub struct TaskExecutor {
     /// Agent registry for looking up agent definitions
@@ -217,26 +251,13 @@ impl TaskExecutor {
             }
         }
 
-        if !agent.permissions.allow.is_empty() || !agent.permissions.deny.is_empty() {
+        if has_defined_permissions(&agent) {
             child_executor.set_guard_policy(Arc::new(agent.permissions.clone())
                 as Arc<dyn crate::permissions::PermissionChecker>);
         }
         let child_executor = Arc::new(child_executor);
 
-        // Inject the agent system prompt via the extra slot.
-        let mut prompt_slots = crate::prompts::SystemPromptSlots::default();
-        if let Some(ref p) = agent.prompt {
-            prompt_slots.extra = Some(p.clone());
-        }
-
-        let child_config = AgentConfig {
-            prompt_slots,
-            tools: child_executor.definitions(),
-            max_tool_rounds: params
-                .max_steps
-                .unwrap_or_else(|| agent.max_steps.unwrap_or(20)),
-            ..AgentConfig::default()
-        };
+        let child_config = build_child_config(&agent, &params, child_executor.definitions());
 
         let tool_context =
             ToolContext::new(PathBuf::from(&self.workspace)).with_session_id(session_id.clone());
@@ -1255,5 +1276,58 @@ mod tests {
         let props = &schema["properties"];
 
         assert!(props.get("permissive").is_none());
+    }
+
+    #[test]
+    fn test_child_config_inherits_agent_permissions() {
+        use crate::permissions::{PermissionDecision, PermissionPolicy};
+
+        let agent = AgentDefinition::new("worker", "Worker")
+            .with_permissions(PermissionPolicy::new().allow("bash(echo:*)"));
+        let params = TaskParams {
+            agent: "worker".to_string(),
+            description: "Run allowed command".to_string(),
+            prompt: "Use bash".to_string(),
+            background: false,
+            max_steps: None,
+        };
+
+        let config = build_child_config(&agent, &params, Vec::new());
+
+        let checker = config
+            .permission_checker
+            .expect("agent permission policy should be installed");
+        assert_eq!(
+            checker.check("bash", &serde_json::json!({"command": "echo ok"})),
+            PermissionDecision::Allow
+        );
+    }
+
+    #[test]
+    fn test_child_config_inherits_default_allow_permissions() {
+        use crate::permissions::{PermissionDecision, PermissionPolicy};
+
+        let permissions = PermissionPolicy {
+            default_decision: PermissionDecision::Allow,
+            ..PermissionPolicy::new()
+        };
+        let agent = AgentDefinition::new("worker", "Worker").with_permissions(permissions);
+        let params = TaskParams {
+            agent: "worker".to_string(),
+            description: "Run any command".to_string(),
+            prompt: "Use bash".to_string(),
+            background: false,
+            max_steps: None,
+        };
+
+        let config = build_child_config(&agent, &params, Vec::new());
+
+        let checker = config
+            .permission_checker
+            .expect("non-default permission policy should be installed");
+        assert_eq!(
+            checker.check("bash", &serde_json::json!({"command": "echo ok"})),
+            PermissionDecision::Allow
+        );
     }
 }


### PR DESCRIPTION
修复 #28。

## 变更内容
- 在 `task` / `parallel_task` 创建子运行时，将被委派 agent 的非默认权限策略写入子 `AgentConfig.permission_checker`。
- 将正常 agent binding 路径里的权限判断改为识别完整的非默认 `PermissionPolicy`，覆盖 `default_decision = Allow` 这类没有 allow/deny 列表但仍然显式配置的策略。
- 增加单元测试，覆盖 allow-list 权限和 default-allow 权限在委派子运行中的继承行为。

## 验证
- `cargo fmt`
- `cargo test -p a3s-code-core --lib`
- `cargo test -p a3s-code-core --lib tools::task::tests`
- `cargo test -p a3s-code-core --lib agent_api::agent_binding::tests`

补充说明：不带 `--lib` 的 `cargo test -p a3s-code-core <filter>` 会编译 integration tests，目前 main 上已有的 `core/tests/test_web_search_headless.rs` 存在 `Option<SearchConfig>` 与 `Option<Arc<SearchConfig>>` 类型不匹配问题，会阻断该命令；这个问题不是本 PR 引入的。