### PR TITLE
ci(publish-python): twine upload --verbose + tag guard

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -108,8 +108,12 @@ jobs:
       - name: List wheels
         run: ls -la dist/
 
-      # Upload native wheels to GitHub Releases (NOT to PyPI)
+      # Upload native wheels to GitHub Releases (NOT to PyPI).
+      # Guarded by a tag check so workflow_dispatch from a branch can still
+      # exercise the PyPI publish path for debugging without the GitHub
+      # Release steps tripping on a missing release name.
       - name: Ensure release exists and upload native assets
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -124,6 +128,7 @@ jobs:
 
       # Generate manifest with wheel metadata for bootstrap downloader
       - name: Generate native wheel manifest
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           python .github/scripts/generate_python_release_manifest.py \
             dist \
@@ -132,6 +137,7 @@ jobs:
 
       # Upload manifest to GitHub Releases
       - name: Upload manifest to GitHub Releases
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -144,4 +150,4 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_NATIVE_TOKEN }}
         run: |
           python -m pip install --upgrade pip twine
-          python -m twine upload --skip-existing dist/*.whl
+          python -m twine upload --verbose --skip-existing dist/*.whl


### PR DESCRIPTION
## Why

The v3.2.0 release (\`release.yml\` run #26338778339) fails on the second wheel upload to PyPI with a generic \`400 Bad Request\`. twine swallows the response body unless \`--verbose\` is set, so we currently can't see the actual reason.

## Changes

1. \`twine upload\` now runs with \`--verbose --skip-existing\`. Next retry will surface the actual PyPI error body.
2. The three GitHub-Release-only steps (\`Ensure release exists\`, \`Generate native wheel manifest\`, \`Upload manifest\`) are now guarded with \`if: startsWith(github.ref, 'refs/tags/')\`. This way \`workflow_dispatch\` from \`main\` (used for debugging) can exercise the PyPI publish path without those steps tripping on a missing release name.

## Plan

After this PR merges to main, dispatch \`publish-python.yml\` manually from main against the v3.2.0 wheels, capture the verbose output, then iterate on the actual root cause.