### PR TITLE
test(bootstrap): make cache-dir assertion version-agnostic (unblock v3.3.0 PyPI publish)

### DIFF
--- a/sdk/python-bootstrap/tests/test_bootstrap.py
+++ b/sdk/python-bootstrap/tests/test_bootstrap.py
@@ -186,7 +186,11 @@ class EnsureNativeLoadedTests(unittest.TestCase):
         ):
             cache = _bootstrap.ensure_native_loaded("3.2.1")
 
-        self.assertEqual(cache, Path(self._tmp) / "3.2.1")
+        # `_cache_root()` keys the cache dir on the module's own __version__,
+        # not the version arg passed to `ensure_native_loaded`. Reference it
+        # directly so this assertion can't go stale on a version bump (the
+        # sibling CacheDirTests follow the same pattern).
+        self.assertEqual(cache, Path(self._tmp) / _bootstrap.__version__)
         # Native file extracted at cache root, not under a subdirectory.
         extracted = list(cache.glob("_native.*"))
         self.assertEqual(len(extracted), 1)


### PR DESCRIPTION
## Why

The v3.3.0 release pipeline (run 26616927410) published **crates.io ✅, npm ✅, and native wheels → GH Release ✅**, but the **publish-python-bootstrap (PyPI)** job failed and **github-release** was consequently skipped.

Root cause: a stale literal in the bootstrap unit test (which the publish job runs before `twine upload`):

```
FAIL: test_downloads_extracts_and_registers_module
    self.assertEqual(cache, Path(self._tmp) / "3.2.1")
AssertionError: PosixPath('.../3.3.0') != PosixPath('.../3.2.1')
```

`_cache_root()` keys the cache dir on the module's own `__version__` (now `3.3.0`), **not** the version argument passed to `ensure_native_loaded("3.2.1")`. The assertion hardcoded `"3.2.1"`, so the version bump broke it.

## Fix

Reference `_bootstrap.__version__` directly — matching the sibling `CacheDirTests` (which already do this) — so the assertion can never go stale on a version bump again. One-line, test-only change.

Verified locally: `python -m unittest tests.test_bootstrap -v` → **15 passed, 1 skipped**.

## Release completion

After merge, the `v3.3.0` tag will be moved to the merge commit and re-pushed. All publish jobs are idempotent (crate curl-check+skip, `npm view`+skip, wheels `--clobber`, twine `--skip-existing`), so the already-published artifacts no-op; only **publish-python-bootstrap** does new work, then **github-release** edits notes onto the existing v3.3.0 release.