### PR TITLE
docs(sdk): codify FFI panic-safety contract at the napi/PyO3 boundary (#32)

### DIFF
--- a/sdk/node/src/lib.rs
+++ b/sdk/node/src/lib.rs
@@ -13,6 +13,27 @@
 //! const result = await session.send('What files handle auth?');
 //! console.log(result.text);
 //! ```
+//!
+//! ## Panic safety at the FFI boundary
+//!
+//! napi 2.x does **not** wrap exported bodies in `catch_unwind` by default. A
+//! Rust panic that reaches the `extern "C"` boundary aborts the whole Node
+//! process (Rust ≥ 1.81) — it does *not* become a catchable JS error. Only two
+//! contexts are panic-safe: a `#[napi]` **async** fn / `impl Future` (panic →
+//! rejected Promise) and a sync fn explicitly tagged `#[napi(catch_unwind)]`.
+//! Everything else aborts (or silently loses the panic): default **sync**
+//! `#[napi]` fns, `ThreadsafeFunction` callbacks (a panic there — or a
+//! return-value conversion `Err` — aborts via `napi_fatal_error` under *both*
+//! `ErrorStrategy` variants), `tokio::spawn`'d task bodies (panic swallowed,
+//! never surfaced), `Drop`/finalizers, and module init.
+//!
+//! Convention this crate follows so the boundary stays safe: never
+//! `.unwrap()` / `.expect()` / `panic!` in those contexts. Propagate with `?`
+//! into a `napi::Error`, or fail closed with `unwrap_or_else` inside
+//! threadsafe callbacks. (Audited 2026-05: the only production panic site is
+//! the lazy Tokio-runtime build in `fallback_runtime()`, reached from within
+//! `#[napi]` bodies; the spawned-task and threadsafe-callback paths are
+//! panic-free by construction.)
 
 #[macro_use]
 extern crate napi_derive;

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -13,6 +13,23 @@
 //! result = session.send("What files handle auth?")
 //! print(result.text)
 //! ```
+//!
+//! ## Panic safety at the FFI boundary
+//!
+//! PyO3 0.23 wraps `#[pyfunction]` / `#[pymethods]` / `#[pymodule]`-init bodies
+//! in `catch_unwind`, so a panic there surfaces as a Python `PanicException`
+//! (a `BaseException` subclass) rather than UB. It does **not** cover panics
+//! inside `std::thread` / `tokio::spawn` task bodies, or `Python::with_gil`
+//! closures invoked from a worker thread *outside* a pyfunction frame — those
+//! are silently lost, and a panicking `Drop` during an unwind aborts the
+//! process.
+//!
+//! Convention this crate follows so the boundary stays safe: the Rust→Python
+//! bridges that run on tokio worker threads (`PythonCallbackHandler`,
+//! `PyBudgetGuard`, `PySlashCommand`) never `.unwrap()` / `panic!`; they use
+//! `.ok()` / `unwrap_or_else` and fail closed. (Audited 2026-05: the only
+//! production panic site is the lazy Tokio-runtime build in `get_runtime()`,
+//! reached only from caught pyfunction frames.)
 
 use a3s_code_core::commands::{
     CommandContext as RustCommandContext, CommandOutput as RustCommandOutput,


### PR DESCRIPTION
Follow-up #32 (FFI panic-unwind safety audit, napi 2.16 / pyo3 0.23).

## Audit outcome: the boundary is panic-safe — verified

A 4-lens audit (napi semantics, PyO3 semantics, per-site classification of both ~6–7K-line `lib.rs` files) plus independent re-verification found **zero production panic sites in an uncaught context**:

- **Node** `sdk/node/src/lib.rs`: 90 panic-prone tokens, but 89 are in `#[cfg(test)]` (line 5352+). The single production site is the lazy Tokio-runtime `.expect()` in `fallback_runtime()` (line 86), reached from within `#[napi]` bodies. `tokio::spawn` bodies just `await` an inner `Result` (`?`-propagated); `ThreadsafeFunction` callbacks fail closed with `unwrap_or_else`; no `impl Drop`.
- **Python** `sdk/python/src/lib.rs`: 42 tokens, 40 in `#[cfg(test)]` (6567+). The single production site is the runtime `.expect()` in `get_runtime()` (line 109), caught by PyO3's pyfunction trampoline. The worker-thread `with_gil` bridges (`PythonCallbackHandler`, `PyBudgetGuard`, `PySlashCommand` — the only truly-uncaught context) use `.ok()`/`unwrap_or_else`/fail-closed; no `tokio::spawn`/`thread::spawn`/`Drop`.

## Why docs, not a refactor

The key finding (verified against the cargo cache, not memory): **napi 2.x does not wrap sync `#[napi]` bodies in `catch_unwind` by default** — a panic there aborts the Node process on Rust ≥ 1.81, it is *not* a catchable JS error. Only `#[napi] async fn` (→ rejected Promise) and `#[napi(catch_unwind)]` are safe. So the boundary's safety rests on a *convention* (never panic in uncaught contexts), not structure — and a future stray `.unwrap()` in a TSFN callback or a new `Drop` impl would silently reintroduce a process-abort.

This PR codifies that contract in each SDK's module doc, where FFI edits will see it. No code change: the only two production panic sites are in framework-caught contexts and fire only on OS thread exhaustion; converting `get_runtime()` to a `Result` would thread through ~75 call sites to defend an already-caught failure — out of proportion (Rule 0).

Doc-only; both SDK crates `cargo fmt --check` clean.