### PR TITLE
[lxt] Allow disabling delegation tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,11 @@ fields, new `SessionStore` trait methods with default no-op impls).
   global `auto_parallel` kill switch. Setting `auto_parallel = false` disables
   automatic parallel child-agent fan-out while keeping manual `parallel_task`
   available.
+- Added `auto_delegation.allow_manual_delegation` and
+  `SessionOptions::with_manual_delegation_enabled(...)` so hosts can hide the
+  model-visible `task` / `parallel_task` tools per session while preserving the
+  child-agent registry for introspection and worker registration. This is an
+  operational cost/debug control, not a security sandbox.
 - Added `max_parallel_tasks` as the shared sibling fan-out limit for
   `parallel_task`, delegated plan waves, and safe parallel write batches.
 - Added a reusable ordered parallel executor so concurrent child results remain

--- a/README.md
+++ b/README.md
@@ -1527,10 +1527,11 @@ skill_dirs = ["./skills"]
 mcp_servers = []
 
 auto_delegation {
-  enabled        = false
-  auto_parallel  = false
-  min_confidence = 0.72
-  max_tasks      = 4
+  enabled                  = false
+  auto_parallel            = false
+  allow_manual_delegation  = true
+  min_confidence           = 0.72
+  max_tasks                = 4
 }
 
 ahp = {
@@ -1549,6 +1550,11 @@ safe parallel write batches.
 `auto_delegation.enabled` controls Claude Code-style automatic subagent
 delegation. `auto_parallel = false` is a global kill switch for automatic
 parallel child-agent fan-out; manual `parallel_task` remains available.
+Set `allow_manual_delegation = false` to hide the model-visible `task` and
+`parallel_task` tools for cost control or debugging while preserving the child
+agent registry for introspection and host-managed worker registration. This is
+not a security sandbox: the parent agent may still use other registered tools,
+MCP servers, or skills.
 
 ---
 

--- a/core/src/agent_api.rs
+++ b/core/src/agent_api.rs
@@ -258,6 +258,12 @@ pub struct SessionOptions {
     pub max_parallel_tasks: Option<usize>,
     /// Per-session automatic subagent delegation override.
     pub auto_delegation: Option<crate::config::AutoDelegationConfig>,
+    /// Per-session switch for model-visible manual child-agent tools.
+    ///
+    /// This overlays the effective automatic delegation config instead of
+    /// replacing it, so callers can hide `task` / `parallel_task` while
+    /// preserving other delegation settings.
+    pub manual_delegation_enabled: Option<bool>,
     /// Per-session kill switch for automatic parallel child-agent fan-out.
     ///
     /// This overlays the effective automatic delegation config instead of

--- a/core/src/agent_api/capabilities.rs
+++ b/core/src/agent_api/capabilities.rs
@@ -18,6 +18,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+const DISABLE_DELEGATION_TOOLS_ENV: &str = "A3S_CODE_DISABLE_DELEGATION_TOOLS";
+
 pub(super) struct SessionCapabilityInput<'a> {
     pub(super) code_config: &'a CodeConfig,
     pub(super) base_config: &'a AgentConfig,
@@ -163,6 +165,9 @@ fn register_task_capability(
     use crate::tools::register_task_with_mcp;
 
     let registry = AgentRegistry::new();
+    let disable_delegation_tools = disable_delegation_tools_from_env(
+        std::env::var(DISABLE_DELEGATION_TOOLS_ENV).ok().as_deref(),
+    );
     let built_in_agent_dirs = built_in_agent_dirs(workspace);
     for dir in code_config
         .agent_dirs
@@ -176,6 +181,10 @@ fn register_task_capability(
     }
     for worker in &opts.worker_agents {
         registry.register_worker(worker.clone());
+    }
+
+    if disable_delegation_tools {
+        return Arc::new(registry);
     }
 
     let parent_context = ChildRunContext {
@@ -201,6 +210,17 @@ fn register_task_capability(
         Some(subagent_tasks),
     );
     registry
+}
+
+fn disable_delegation_tools_from_env(value: Option<&str>) -> bool {
+    value
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
 }
 
 fn built_in_agent_dirs(workspace: &Path) -> Vec<PathBuf> {
@@ -263,6 +283,26 @@ fn group_mcp_tools_by_server(all_tools: Vec<(String, McpTool)>) -> HashMap<Strin
         by_server.entry(server).or_insert_with(Vec::new).push(tool);
     }
     by_server
+}
+
+#[cfg(test)]
+mod tests {
+    use super::disable_delegation_tools_from_env;
+
+    #[test]
+    fn disable_delegation_tools_accepts_common_truthy_values() {
+        for value in ["1", "true", "TRUE", " yes ", "on", "On"] {
+            assert!(disable_delegation_tools_from_env(Some(value)));
+        }
+    }
+
+    #[test]
+    fn disable_delegation_tools_rejects_empty_missing_and_falsey_values() {
+        for value in ["", "0", "false", "no", "off", "enabled"] {
+            assert!(!disable_delegation_tools_from_env(Some(value)));
+        }
+        assert!(!disable_delegation_tools_from_env(None));
+    }
 }
 
 fn build_context_providers(

--- a/core/src/agent_api/capabilities.rs
+++ b/core/src/agent_api/capabilities.rs
@@ -18,8 +18,6 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-const DISABLE_DELEGATION_TOOLS_ENV: &str = "A3S_CODE_DISABLE_DELEGATION_TOOLS";
-
 pub(super) struct SessionCapabilityInput<'a> {
     pub(super) code_config: &'a CodeConfig,
     pub(super) base_config: &'a AgentConfig,
@@ -165,9 +163,7 @@ fn register_task_capability(
     use crate::tools::register_task_with_mcp;
 
     let registry = AgentRegistry::new();
-    let disable_delegation_tools = disable_delegation_tools_from_env(
-        std::env::var(DISABLE_DELEGATION_TOOLS_ENV).ok().as_deref(),
-    );
+    let auto_delegation = super::session_config::resolve_auto_delegation_config(code_config, opts);
     let built_in_agent_dirs = built_in_agent_dirs(workspace);
     for dir in code_config
         .agent_dirs
@@ -183,7 +179,9 @@ fn register_task_capability(
         registry.register_worker(worker.clone());
     }
 
-    if disable_delegation_tools {
+    if !auto_delegation.allow_manual_delegation {
+        // Keep the registry populated for introspection and host-managed worker
+        // registration even when the model-visible delegation tools are hidden.
         return Arc::new(registry);
     }
 
@@ -210,17 +208,6 @@ fn register_task_capability(
         Some(subagent_tasks),
     );
     registry
-}
-
-fn disable_delegation_tools_from_env(value: Option<&str>) -> bool {
-    value
-        .map(|value| {
-            matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-        })
-        .unwrap_or(false)
 }
 
 fn built_in_agent_dirs(workspace: &Path) -> Vec<PathBuf> {
@@ -283,26 +270,6 @@ fn group_mcp_tools_by_server(all_tools: Vec<(String, McpTool)>) -> HashMap<Strin
         by_server.entry(server).or_insert_with(Vec::new).push(tool);
     }
     by_server
-}
-
-#[cfg(test)]
-mod tests {
-    use super::disable_delegation_tools_from_env;
-
-    #[test]
-    fn disable_delegation_tools_accepts_common_truthy_values() {
-        for value in ["1", "true", "TRUE", " yes ", "on", "On"] {
-            assert!(disable_delegation_tools_from_env(Some(value)));
-        }
-    }
-
-    #[test]
-    fn disable_delegation_tools_rejects_empty_missing_and_falsey_values() {
-        for value in ["", "0", "false", "no", "off", "enabled"] {
-            assert!(!disable_delegation_tools_from_env(Some(value)));
-        }
-        assert!(!disable_delegation_tools_from_env(None));
-    }
 }
 
 fn build_context_providers(

--- a/core/src/agent_api/session_builder.rs
+++ b/core/src/agent_api/session_builder.rs
@@ -15,7 +15,9 @@ use std::sync::{Arc, RwLock};
 use super::capabilities::{
     build_session_capabilities, register_skill_capability, SessionCapabilityInput,
 };
-use super::session_config::{resolve_session_memory, resolve_session_store};
+use super::session_config::{
+    resolve_auto_delegation_config, resolve_session_memory, resolve_session_store,
+};
 use super::session_runtime::{build_session_runtime, SessionRuntimeInput};
 
 pub(super) fn prepare_session_options(agent: &Agent, opts: SessionOptions) -> SessionOptions {
@@ -135,13 +137,7 @@ pub(super) fn build_agent_session(
     let init_warning = resolved_memory.init_warning;
 
     let base = agent.config.clone();
-    let mut auto_delegation = opts
-        .auto_delegation
-        .clone()
-        .unwrap_or_else(|| base.auto_delegation.clone());
-    if let Some(auto_parallel) = opts.auto_parallel_delegation {
-        auto_delegation.auto_parallel = auto_parallel;
-    }
+    let auto_delegation = resolve_auto_delegation_config(&agent.code_config, opts);
     let config = AgentConfig {
         prompt_slots,
         tools: tool_defs,

--- a/core/src/agent_api/session_config.rs
+++ b/core/src/agent_api/session_config.rs
@@ -5,6 +5,29 @@ use crate::llm::LlmClient;
 use anyhow::Context;
 use std::sync::Arc;
 
+pub(super) fn resolve_auto_delegation_config(
+    code_config: &CodeConfig,
+    opts: &SessionOptions,
+) -> crate::config::AutoDelegationConfig {
+    let mut auto_delegation = if let Some(config) = opts.auto_delegation.clone() {
+        config
+    } else {
+        let mut config = code_config.auto_delegation.clone();
+        if let Some(auto_parallel) = code_config.auto_parallel {
+            config.auto_parallel = auto_parallel;
+        }
+        config
+    };
+    if let Some(enabled) = opts.manual_delegation_enabled {
+        auto_delegation.allow_manual_delegation = enabled;
+    }
+    if let Some(auto_parallel) = opts.auto_parallel_delegation {
+        auto_delegation.auto_parallel = auto_parallel;
+    }
+
+    auto_delegation
+}
+
 pub(super) fn resolve_session_llm_client(
     code_config: &CodeConfig,
     opts: &SessionOptions,

--- a/core/src/agent_api/session_options.rs
+++ b/core/src/agent_api/session_options.rs
@@ -54,6 +54,7 @@ impl std::fmt::Debug for SessionOptions {
             .field("max_tool_rounds", &self.max_tool_rounds)
             .field("max_parallel_tasks", &self.max_parallel_tasks)
             .field("auto_delegation", &self.auto_delegation)
+            .field("manual_delegation_enabled", &self.manual_delegation_enabled)
             .field("auto_parallel_delegation", &self.auto_parallel_delegation)
             .field("prompt_slots", &self.prompt_slots.is_some())
             .finish()
@@ -491,6 +492,20 @@ impl SessionOptions {
         let mut config = self.auto_delegation.take().unwrap_or_default();
         config.enabled = enabled;
         self.auto_delegation = Some(config);
+        self
+    }
+
+    /// Enable or disable model-visible manual child-agent tools for this session.
+    ///
+    /// When false, `task` and `parallel_task` are not registered in the session
+    /// tool surface. Worker agents remain registered for introspection and hosts
+    /// that manage them directly. This is for cost control or debugging; it is
+    /// not a security sandbox for the parent agent.
+    pub fn with_manual_delegation_enabled(mut self, enabled: bool) -> Self {
+        if let Some(config) = &mut self.auto_delegation {
+            config.allow_manual_delegation = enabled;
+        }
+        self.manual_delegation_enabled = Some(enabled);
         self
     }
 

--- a/core/src/agent_api/tests.rs
+++ b/core/src/agent_api/tests.rs
@@ -1807,6 +1807,26 @@ async fn test_session_uses_single_delegation_tool_surface() {
     assert!(!names.contains(&"run_team".to_string()));
 }
 
+#[tokio::test]
+async fn test_session_can_disable_manual_delegation_tools_without_dropping_registry() {
+    let agent = Agent::from_config(test_config()).await.unwrap();
+    let opts = SessionOptions::new()
+        .with_worker_agent(crate::subagent::WorkerAgentSpec::planner(
+            "release-planner",
+            "Plan releases",
+        ))
+        .with_manual_delegation_enabled(false);
+    let session = agent
+        .session("/tmp/test-workspace-no-manual-delegation", Some(opts))
+        .unwrap();
+    let names = session.tool_names();
+
+    assert!(!names.contains(&"task".to_string()));
+    assert!(!names.contains(&"parallel_task".to_string()));
+    assert!(session.agent_registry.exists("release-planner"));
+    assert!(!session.config.auto_delegation.allow_manual_delegation);
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_session_with_queue_config() {
     let agent = Agent::from_config(test_config()).await.unwrap();
@@ -2621,13 +2641,16 @@ async fn test_session_options_builders() {
         .with_auto_save(true)
         .with_max_parallel_tasks(3)
         .with_auto_delegation_enabled(true)
+        .with_manual_delegation_enabled(false)
         .with_auto_parallel_delegation(false);
     assert_eq!(opts.session_id, Some("test-id".to_string()));
     assert!(opts.auto_save);
     assert_eq!(opts.max_parallel_tasks, Some(3));
+    assert_eq!(opts.manual_delegation_enabled, Some(false));
     assert_eq!(opts.auto_parallel_delegation, Some(false));
     let auto = opts.auto_delegation.expect("auto delegation config");
     assert!(auto.enabled);
+    assert!(!auto.allow_manual_delegation);
     assert!(!auto.auto_parallel);
 }
 

--- a/core/src/config/loader.rs
+++ b/core/src/config/loader.rs
@@ -72,6 +72,17 @@ fn parse_auto_delegation_block(
     {
         config.auto_parallel = auto_parallel;
     }
+    if let Some(allow_manual_delegation) = acl_bool_attr(
+        block,
+        &[
+            "allow_manual_delegation",
+            "allowManualDelegation",
+            "manual_delegation",
+            "manualDelegation",
+        ],
+    ) {
+        config.allow_manual_delegation = allow_manual_delegation;
+    }
     if let Some(min_confidence) = acl_f32_attr(block, &["min_confidence", "minConfidence"]) {
         config.min_confidence = min_confidence.clamp(0.0, 1.0);
     }

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -61,6 +61,14 @@ pub struct AutoDelegationConfig {
     /// Manual `parallel_task` calls remain available when this is false.
     #[serde(alias = "auto_parallel")]
     pub auto_parallel: bool,
+    /// Allow model-visible manual `task` and `parallel_task` delegation tools.
+    ///
+    /// Set this to false for cost control or debugging when child-agent tools
+    /// should be absent from the session tool surface. This is not a security
+    /// sandbox: the parent agent may still have other tools such as `bash`,
+    /// MCP tools, or skills.
+    #[serde(alias = "allow_manual_delegation")]
+    pub allow_manual_delegation: bool,
     /// Minimum local confidence required to auto-delegate a child task.
     pub min_confidence: f32,
     /// Maximum number of automatic child tasks per user request.
@@ -72,6 +80,7 @@ impl Default for AutoDelegationConfig {
         Self {
             enabled: false,
             auto_parallel: true,
+            allow_manual_delegation: true,
             min_confidence: 0.72,
             max_tasks: 4,
         }

--- a/core/src/config/tests.rs
+++ b/core/src/config/tests.rs
@@ -54,6 +54,7 @@ fn test_config_with_storage_backend() {
             auto_delegation {
               enabled = true
               auto_parallel = true
+              allow_manual_delegation = false
               min_confidence = 0.8
               max_tasks = 2
             }
@@ -67,6 +68,7 @@ fn test_config_with_storage_backend() {
     assert_eq!(config.max_parallel_tasks, Some(3));
     assert!(config.auto_delegation.enabled);
     assert!(!config.auto_delegation.auto_parallel);
+    assert!(!config.auto_delegation.allow_manual_delegation);
     assert!((config.auto_delegation.min_confidence - 0.8).abs() < f32::EPSILON);
     assert_eq!(config.auto_delegation.max_tasks, 2);
 }


### PR DESCRIPTION
## Summary
- add A3S_CODE_DISABLE_DELEGATION_TOOLS to skip registering task and parallel_task
- keep agent registry loading so session worker definitions remain available
- add parser unit tests for common truthy and falsey values

## Validation
- /mnt/shared-storage-user/lixiangtian/.cargo/bin/cargo fmt --check
- /mnt/shared-storage-user/lixiangtian/.cargo/bin/cargo test -p a3s-code-core disable_delegation_tools -- --nocapture