### PR TITLE
chore(release): bump version to 3.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "a3s-acl 0.2.0",
  "a3s-ahp",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-core"
-version = "3.4.0"
+version = "3.5.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-node"
-version = "3.4.0"
+version = "3.5.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "3.4.0", path = "../../core", features = ["ahp", "s3"] }
+a3s-code-core = { version = "3.5.0", path = "../../core", features = ["ahp", "s3"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }

--- a/sdk/node/examples/package-lock.json
+++ b/sdk/node/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@a3s-lab/code",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -27,12 +27,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "3.4.0",
-        "@a3s-lab/code-linux-arm64-gnu": "3.4.0",
-        "@a3s-lab/code-linux-arm64-musl": "3.4.0",
-        "@a3s-lab/code-linux-x64-gnu": "3.4.0",
-        "@a3s-lab/code-linux-x64-musl": "3.4.0",
-        "@a3s-lab/code-win32-x64-msvc": "3.4.0"
+        "@a3s-lab/code-darwin-arm64": "3.5.0",
+        "@a3s-lab/code-linux-arm64-gnu": "3.5.0",
+        "@a3s-lab/code-linux-arm64-musl": "3.5.0",
+        "@a3s-lab/code-linux-x64-gnu": "3.5.0",
+        "@a3s-lab/code-linux-x64-musl": "3.5.0",
+        "@a3s-lab/code-win32-x64-msvc": "3.5.0"
       }
     },
     "node_modules/@a3s-lab/code": {

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/code",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/code",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -15,12 +15,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "3.4.0",
-        "@a3s-lab/code-linux-arm64-gnu": "3.4.0",
-        "@a3s-lab/code-linux-arm64-musl": "3.4.0",
-        "@a3s-lab/code-linux-x64-gnu": "3.4.0",
-        "@a3s-lab/code-linux-x64-musl": "3.4.0",
-        "@a3s-lab/code-win32-x64-msvc": "3.4.0"
+        "@a3s-lab/code-darwin-arm64": "3.5.0",
+        "@a3s-lab/code-linux-arm64-gnu": "3.5.0",
+        "@a3s-lab/code-linux-arm64-musl": "3.5.0",
+        "@a3s-lab/code-linux-x64-gnu": "3.5.0",
+        "@a3s-lab/code-linux-x64-musl": "3.5.0",
+        "@a3s-lab/code-win32-x64-msvc": "3.5.0"
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/code",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "A3S Code - Native Node.js bindings for the coding-agent runtime",
   "main": "index.js",
   "types": "index.d.ts",
@@ -43,11 +43,11 @@
     "test:helpers": "node test-helpers.mjs"
   },
   "optionalDependencies": {
-    "@a3s-lab/code-darwin-arm64": "3.4.0",
-    "@a3s-lab/code-linux-x64-gnu": "3.4.0",
-    "@a3s-lab/code-linux-x64-musl": "3.4.0",
-    "@a3s-lab/code-linux-arm64-gnu": "3.4.0",
-    "@a3s-lab/code-linux-arm64-musl": "3.4.0",
-    "@a3s-lab/code-win32-x64-msvc": "3.4.0"
+    "@a3s-lab/code-darwin-arm64": "3.5.0",
+    "@a3s-lab/code-linux-x64-gnu": "3.5.0",
+    "@a3s-lab/code-linux-x64-musl": "3.5.0",
+    "@a3s-lab/code-linux-arm64-gnu": "3.5.0",
+    "@a3s-lab/code-linux-arm64-musl": "3.5.0",
+    "@a3s-lab/code-win32-x64-msvc": "3.5.0"
   }
 }

--- a/sdk/python-bootstrap/pyproject.toml
+++ b/sdk/python-bootstrap/pyproject.toml
@@ -7,7 +7,7 @@ name = "a3s-code"
 # Keep in sync with crates/code core release. The bootstrap loader fetches
 # the matching native wheel from `https://github.com/AI45Lab/Code/releases/tag/v<version>`
 # at import time.
-version = "3.4.0"
+version = "3.5.0"
 description = "A3S Code Python SDK — pure-Python bootstrap that fetches the native wheel from GitHub Releases"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
+++ b/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 # Version is the bootstrap's own version, which equals the matching native
 # wheel version on GH Releases. Bumped by the release workflow.
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 
 _DEFAULT_BASE_URL = "https://github.com/AI45Lab/Code/releases/download"
 _REQUEST_TIMEOUT_S = 120

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-py"
-version = "3.4.0"
+version = "3.5.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "3.4.0", path = "../../core", features = ["ahp", "s3"] }
+a3s-code-core = { version = "3.5.0", path = "../../core", features = ["ahp", "s3"] }
 pyo3 = "0.23"
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "a3s-code"
-version = "3.4.0"
+version = "3.5.0"
 description = "A3S Code - Native Python bindings for the coding-agent runtime"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Bumps all version-sync artifacts 3.4.0 → 3.5.0 (core + Node/Python SDK crates, `package.json` + lockfiles, Python SDK + bootstrap shim, `Cargo.lock`). `check-version.sh` reports consistent at 3.5.0; clippy/fmt clean.

**3.5.0** ships the programmable dynamic-workflow mechanism merged in #64: the `Workflow` facade, `execute_loop` / `LoopDecision`, the shared `WorkflowBudget`, the `parallel(specs, budgetTokens?)` overload, plus the parallel-write safety-gate fix.

Merging this, then tagging `v3.5.0`, triggers the release workflow (crates.io / npm / GitHub Release).