### PR TITLE
feat(api): wire LlmClient injection seam; stop stderr writes; prune dead Planner trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Framework-vs-host boundary tightening: wire the one missing Action-layer seam,
+stop the framework writing to the host's output channel, and prune a dead
+abstraction.
+
+### Added
+
+- **`SessionOptions::with_llm_client`** — hosts can now inject a custom
+  `Arc<dyn LlmClient>` (custom/unsupported provider, deterministic record/replay
+  client, or HTTP proxy/audit wrapper). The `LlmClient` trait and `Arc<dyn>`
+  engine already existed but were only injectable in test code; this wires the
+  seam through the public API, bringing the Action-layer backend to parity with
+  workspace/memory/store/security (all object-injectable). The `provider/model`
+  factory remains the default when unset.
+
+### Fixed
+
+- **Framework no longer writes to the host's stderr** — replaced a stray
+  `eprintln!("[DEBUG] HTTP error...")` in the OpenAI client (fired on every
+  transport error, also leaking into the host terminal) with `tracing::error!`,
+  consistent with the rest of the crate.
+
+### Removed
+
+- **Dead `Planner` trait** (`planning::Planner`) — it was re-exported but had no
+  `dyn Planner` dispatch and no consumer; every call site uses `LlmPlanner`'s
+  inherent methods directly. Removed per the pruning rule (the real variability,
+  the LLM, is swappable via `with_llm_client`). `LlmPlanner` is unchanged.
+
 ## [3.4.0] - 2026-05-30
 
 Programmable, deterministic multi-agent orchestration — a grammar for

--- a/core/src/agent_api.rs
+++ b/core/src/agent_api.rs
@@ -136,6 +136,14 @@ pub struct SessionOptions {
     pub queue_config: Option<SessionQueueConfig>,
     /// Optional security provider for taint tracking and output sanitization
     pub security_provider: Option<Arc<dyn crate::security::SecurityProvider>>,
+    /// Optional host-supplied LLM client.
+    ///
+    /// When set, it is used directly, overriding the `provider/model`
+    /// factory resolution — the one Action-layer backend that was previously
+    /// only injectable in test code. Lets a host plug in a provider the
+    /// built-in factory does not cover, a deterministic record/replay client,
+    /// or an HTTP-layer proxy/audit wrapper. Mirrors `workspace_services`.
+    pub llm_client: Option<Arc<dyn crate::llm::LlmClient>>,
     /// Optional context providers for RAG
     pub context_providers: Vec<Arc<dyn crate::context::ContextProvider>>,
     /// Optional confirmation manager for HITL

--- a/core/src/agent_api/session_config.rs
+++ b/core/src/agent_api/session_config.rs
@@ -10,6 +10,13 @@ pub(super) fn resolve_session_llm_client(
     opts: &SessionOptions,
     session_id: Option<&str>,
 ) -> Result<Arc<dyn LlmClient>> {
+    // A host-supplied client overrides the provider-string factory entirely:
+    // the host owns the full Action-layer dependency (custom provider, replay
+    // client, proxy/audit wrapper). Config-based model resolution is bypassed.
+    if let Some(ref client) = opts.llm_client {
+        return Ok(Arc::clone(client));
+    }
+
     let model_ref = if let Some(ref model) = opts.model {
         model.as_str()
     } else {
@@ -91,6 +98,62 @@ pub(super) fn resolve_session_memory(opts: &SessionOptions) -> ResolvedSessionMe
     ResolvedSessionMemory {
         memory: store.map(|s| Arc::new(crate::memory::AgentMemory::new(s))),
         init_warning,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::{LlmResponse, Message, StreamEvent, ToolDefinition};
+    // The LlmClient trait returns anyhow::Result; shadow super's crate::error::Result.
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+
+    struct DummyClient;
+
+    #[async_trait]
+    impl LlmClient for DummyClient {
+        async fn complete(
+            &self,
+            _: &[Message],
+            _: Option<&str>,
+            _: &[ToolDefinition],
+        ) -> Result<LlmResponse> {
+            anyhow::bail!("resolver short-circuits before the client is called")
+        }
+        async fn complete_streaming(
+            &self,
+            _: &[Message],
+            _: Option<&str>,
+            _: &[ToolDefinition],
+            _: CancellationToken,
+        ) -> Result<mpsc::Receiver<StreamEvent>> {
+            anyhow::bail!("not used")
+        }
+    }
+
+    // A default CodeConfig has no default_model, so the provider-string factory
+    // path errors — proving the override is what makes resolution succeed.
+    #[test]
+    fn host_supplied_llm_client_overrides_factory() {
+        let config = CodeConfig::default();
+        let opts = SessionOptions::new().with_llm_client(Arc::new(DummyClient));
+        assert!(
+            resolve_session_llm_client(&config, &opts, None).is_ok(),
+            "with_llm_client must bypass provider/model config resolution"
+        );
+    }
+
+    #[test]
+    fn without_llm_client_missing_default_model_errors() {
+        let config = CodeConfig::default();
+        let opts = SessionOptions::new();
+        assert!(
+            resolve_session_llm_client(&config, &opts, None).is_err(),
+            "no host client + no default_model should error (control case)"
+        );
     }
 }
 

--- a/core/src/agent_api/session_options.rs
+++ b/core/src/agent_api/session_options.rs
@@ -21,6 +21,7 @@ impl std::fmt::Debug for SessionOptions {
             .field("skill_dirs", &self.skill_dirs)
             .field("queue_config", &self.queue_config)
             .field("security_provider", &self.security_provider.is_some())
+            .field("llm_client", &self.llm_client.is_some())
             .field("context_providers", &self.context_providers.len())
             .field("confirmation_manager", &self.confirmation_manager.is_some())
             .field("permission_checker", &self.permission_checker.is_some())
@@ -107,6 +108,18 @@ impl SessionOptions {
         provider: Arc<dyn crate::security::SecurityProvider>,
     ) -> Self {
         self.security_provider = Some(provider);
+        self
+    }
+
+    /// Provide a custom LLM client for this session.
+    ///
+    /// When set, this client is used directly, overriding the `provider/model`
+    /// factory resolution. Use it to plug in a provider the built-in factory
+    /// does not cover, a deterministic record/replay client for tests, or an
+    /// HTTP-layer proxy/audit wrapper. Mirrors [`Self::with_workspace_backend`];
+    /// the `provider/model` config path remains the default when unset.
+    pub fn with_llm_client(mut self, client: Arc<dyn crate::llm::LlmClient>) -> Self {
+        self.llm_client = Some(client);
         self
     }
 

--- a/core/src/llm/openai.rs
+++ b/core/src/llm/openai.rs
@@ -356,7 +356,7 @@ impl LlmClient for OpenAiClient {
                             }
                         }
                         Err(e) => {
-                            eprintln!("[DEBUG] HTTP error: {:?}", e);
+                            tracing::error!("HTTP error: {e:?}");
                             AttemptOutcome::Fatal(e)
                         }
                     }

--- a/core/src/planning/llm_planner.rs
+++ b/core/src/planning/llm_planner.rs
@@ -7,7 +7,6 @@
 use crate::llm::{LlmClient, Message};
 use crate::planning::{AgentGoal, Complexity, ExecutionPlan, Task};
 use anyhow::{Context, Result};
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -31,27 +30,6 @@ pub struct PreAnalysis {
     pub execution_plan: ExecutionPlan,
     /// LLM-rewritten version of the user input with ambiguities resolved.
     pub optimized_input: String,
-}
-
-/// Trait for planning providers
-///
-/// Abstracts plan generation, goal extraction, and achievement evaluation.
-/// Allows different implementations (LLM-based, heuristic, test mocks).
-#[async_trait]
-pub trait Planner: Send + Sync {
-    /// Generate an execution plan from a prompt
-    async fn create_plan(&self, llm: &Arc<dyn LlmClient>, prompt: &str) -> Result<ExecutionPlan>;
-
-    /// Extract a goal with success criteria from a prompt
-    async fn extract_goal(&self, llm: &Arc<dyn LlmClient>, prompt: &str) -> Result<AgentGoal>;
-
-    /// Evaluate whether a goal has been achieved given current state
-    async fn check_achievement(
-        &self,
-        llm: &Arc<dyn LlmClient>,
-        goal: &AgentGoal,
-        current_state: &str,
-    ) -> Result<AchievementResult>;
 }
 
 /// LLM-powered planner that generates plans, extracts goals, and evaluates achievement
@@ -377,27 +355,6 @@ impl LlmPlanner {
         }
 
         trimmed
-    }
-}
-
-// Implement Planner trait for LlmPlanner
-#[async_trait]
-impl Planner for LlmPlanner {
-    async fn create_plan(&self, llm: &Arc<dyn LlmClient>, prompt: &str) -> Result<ExecutionPlan> {
-        LlmPlanner::create_plan(llm, prompt).await
-    }
-
-    async fn extract_goal(&self, llm: &Arc<dyn LlmClient>, prompt: &str) -> Result<AgentGoal> {
-        LlmPlanner::extract_goal(llm, prompt).await
-    }
-
-    async fn check_achievement(
-        &self,
-        llm: &Arc<dyn LlmClient>,
-        goal: &AgentGoal,
-        current_state: &str,
-    ) -> Result<AchievementResult> {
-        LlmPlanner::check_achievement(llm, goal, current_state).await
     }
 }
 

--- a/core/src/planning/mod.rs
+++ b/core/src/planning/mod.rs
@@ -7,7 +7,7 @@
 
 pub mod llm_planner;
 
-pub use llm_planner::{AchievementResult, LlmPlanner, Planner, PreAnalysis};
+pub use llm_planner::{AchievementResult, LlmPlanner, PreAnalysis};
 
 use serde::{Deserialize, Serialize};
 use std::fmt;


### PR DESCRIPTION
Framework-vs-host boundary tightening from an architecture audit of `core`. Independent of #67 (prompt hardening) — touches a disjoint set of files.

The audit's guiding rule: the framework owns **mechanism/protocol**; the host owns **presentation/input-syntax/business-policy**. A built-in should be a replaceable extension point only when a concrete present consumer needs it (no future-proofing).

## Added — `SessionOptions::with_llm_client(Arc<dyn LlmClient>)`
The one real missing seam. `LlmClient` is already a public trait and the whole engine runs on `Arc<dyn LlmClient>`, but **no public path let a host inject one** — every session resolved via a hardcoded provider-string factory, and the only injecting constructor (`build_session`) is `#[cfg(test)]`. This violated the repo's own "Typed Extension Options" rule (backends must be swappable as typed objects, not selected by a raw provider name) — and it was the *only* Action-layer backend that did, while workspace/memory/store/security are all object-injectable.

- `resolve_session_llm_client` now returns a host-supplied client when present, else the existing `provider/model` factory (unchanged default).
- Unblocks: providers the factory doesn't cover, a deterministic record/replay client (mirroring `FixedClock`/`SequentialIdGenerator`), and proxy/audit HTTP wrappers — without forking core.

## Fixed — framework no longer writes to the host's stderr
Replaced a stray `eprintln!("[DEBUG] HTTP error...")` in the OpenAI client (fired on every transport error, dumping `[DEBUG]` to every consumer's terminal) with `tracing::error!`, consistent with the rest of the crate.

## Removed — dead `Planner` trait (`planning::Planner`)
Re-exported but had **zero** `dyn Planner` dispatch and no consumer; every call site uses `LlmPlanner`'s inherent methods directly. Pruned per the pruning rule — the only real variability (the LLM) is now swappable via `with_llm_client`. `LlmPlanner` itself is unchanged.

## Testing
- 2 new resolver unit tests: a host-supplied client bypasses `provider/model` config; the control case (no client + no `default_model`) errors.
- `cargo test -p a3s-code-core --lib`: **1757 passed, 0 failed**. `clippy` clean. `cargo fmt --check` clean.

## Notes
No version bump (left to the maintainer's release flow). Slash-command de-UX (the larger boundary item from the same audit) is intentionally **not** included — it changes a public behavior surface and needs a product decision first.