### PR TITLE
chore(release): 3.6.1 — fix SDK release build (pin toolchain + refresh locks)

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -42,7 +42,10 @@ jobs:
           node-version: 20
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned: brotli 8.0.3 (transitive via tower-http, ahp/s3 features) fails
+        # to compile on newer stable rustc; 1.94.1 is the known-good build that
+        # shipped earlier releases. Revisit when the brotli/toolchain break clears.
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           targets: ${{ matrix.settings.target }}
 

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -60,7 +60,10 @@ jobs:
             3.13
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned: brotli 8.0.3 (transitive via tower-http, ahp/s3 features) fails
+        # to compile on newer stable rustc; 1.94.1 is the known-good build that
+        # shipped earlier releases. Revisit when the brotli/toolchain break clears.
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           targets: ${{ matrix.settings.target }}
 
@@ -82,6 +85,9 @@ jobs:
           target: ${{ matrix.settings.target }}
           args: --release --out dist --manifest-path sdk/python/Cargo.toml -i python3.10 -i python3.11 -i python3.12 -i python3.13
           manylinux: ${{ matrix.settings.manylinux || 'auto' }}
+          # Pin the toolchain maturin installs (incl. inside the manylinux
+          # container) so brotli 8.0.3 compiles. See "Install Rust" note above.
+          rust-toolchain: 1.94.1
 
       - name: Upload wheels to GitHub Releases
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1] - 2026-06-14
+
+Release-engineering fix for 3.6.0 (no library code changes). The 3.6.0 tag
+published `a3s-code-core` to crates.io, but the native SDK build jobs failed
+because **brotli 8.0.3** (pulled transitively via `tower-http` under the
+`ahp`/`s3` features) no longer compiles on the newest stable Rust — so the npm,
+PyPI, and GitHub Release artifacts were skipped. This release ships those.
+
+### Fixed
+
+- **Pin the SDK build toolchain** — `publish-node.yml` / `publish-python.yml`
+  now use `dtolnay/rust-toolchain@1.94.1` (and pass `rust-toolchain: 1.94.1` to
+  `maturin-action`) instead of `@stable`, restoring the known-good build that
+  shipped earlier releases. Revisit when the upstream brotli/toolchain break
+  clears.
+- **Refresh the SDK lockfiles** — `sdk/{node,python}/Cargo.lock` now pin
+  `a3s-code-core` to the release version (previously left stale, which forced a
+  dependency re-resolution that pulled a second `alloc-no-stdlib`).
+
 ## [3.6.0] - 2026-06-14
 
 A system-prompt hardening pass plus framework-vs-host boundary tightening:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "3.6.0"
+version = "3.6.1"
 dependencies = [
  "a3s-acl 0.2.0",
  "a3s-ahp",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-core"
-version = "3.6.0"
+version = "3.6.1"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-node"
-version = "3.6.0"
+version = "3.6.1"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "3.6.0", path = "../../core", features = ["ahp", "s3"] }
+a3s-code-core = { version = "3.6.1", path = "../../core", features = ["ahp", "s3"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }

--- a/sdk/node/examples/package-lock.json
+++ b/sdk/node/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@a3s-lab/code",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -27,12 +27,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "3.6.0",
-        "@a3s-lab/code-linux-arm64-gnu": "3.6.0",
-        "@a3s-lab/code-linux-arm64-musl": "3.6.0",
-        "@a3s-lab/code-linux-x64-gnu": "3.6.0",
-        "@a3s-lab/code-linux-x64-musl": "3.6.0",
-        "@a3s-lab/code-win32-x64-msvc": "3.6.0"
+        "@a3s-lab/code-darwin-arm64": "3.6.1",
+        "@a3s-lab/code-linux-arm64-gnu": "3.6.1",
+        "@a3s-lab/code-linux-arm64-musl": "3.6.1",
+        "@a3s-lab/code-linux-x64-gnu": "3.6.1",
+        "@a3s-lab/code-linux-x64-musl": "3.6.1",
+        "@a3s-lab/code-win32-x64-msvc": "3.6.1"
       }
     },
     "node_modules/@a3s-lab/code": {

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/code",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/code",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -15,12 +15,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "3.6.0",
-        "@a3s-lab/code-linux-arm64-gnu": "3.6.0",
-        "@a3s-lab/code-linux-arm64-musl": "3.6.0",
-        "@a3s-lab/code-linux-x64-gnu": "3.6.0",
-        "@a3s-lab/code-linux-x64-musl": "3.6.0",
-        "@a3s-lab/code-win32-x64-msvc": "3.6.0"
+        "@a3s-lab/code-darwin-arm64": "3.6.1",
+        "@a3s-lab/code-linux-arm64-gnu": "3.6.1",
+        "@a3s-lab/code-linux-arm64-musl": "3.6.1",
+        "@a3s-lab/code-linux-x64-gnu": "3.6.1",
+        "@a3s-lab/code-linux-x64-musl": "3.6.1",
+        "@a3s-lab/code-win32-x64-msvc": "3.6.1"
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/code",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "A3S Code - Native Node.js bindings for the coding-agent runtime",
   "main": "index.js",
   "types": "index.d.ts",
@@ -43,11 +43,11 @@
     "test:helpers": "node test-helpers.mjs"
   },
   "optionalDependencies": {
-    "@a3s-lab/code-darwin-arm64": "3.6.0",
-    "@a3s-lab/code-linux-x64-gnu": "3.6.0",
-    "@a3s-lab/code-linux-x64-musl": "3.6.0",
-    "@a3s-lab/code-linux-arm64-gnu": "3.6.0",
-    "@a3s-lab/code-linux-arm64-musl": "3.6.0",
-    "@a3s-lab/code-win32-x64-msvc": "3.6.0"
+    "@a3s-lab/code-darwin-arm64": "3.6.1",
+    "@a3s-lab/code-linux-x64-gnu": "3.6.1",
+    "@a3s-lab/code-linux-x64-musl": "3.6.1",
+    "@a3s-lab/code-linux-arm64-gnu": "3.6.1",
+    "@a3s-lab/code-linux-arm64-musl": "3.6.1",
+    "@a3s-lab/code-win32-x64-msvc": "3.6.1"
   }
 }

--- a/sdk/python-bootstrap/pyproject.toml
+++ b/sdk/python-bootstrap/pyproject.toml
@@ -7,7 +7,7 @@ name = "a3s-code"
 # Keep in sync with crates/code core release. The bootstrap loader fetches
 # the matching native wheel from `https://github.com/AI45Lab/Code/releases/tag/v<version>`
 # at import time.
-version = "3.6.0"
+version = "3.6.1"
 description = "A3S Code Python SDK — pure-Python bootstrap that fetches the native wheel from GitHub Releases"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
+++ b/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 # Version is the bootstrap's own version, which equals the matching native
 # wheel version on GH Releases. Bumped by the release workflow.
-__version__ = "3.6.0"
+__version__ = "3.6.1"
 
 _DEFAULT_BASE_URL = "https://github.com/AI45Lab/Code/releases/download"
 _REQUEST_TIMEOUT_S = 120

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-py"
-version = "3.6.0"
+version = "3.6.1"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "3.6.0", path = "../../core", features = ["ahp", "s3"] }
+a3s-code-core = { version = "3.6.1", path = "../../core", features = ["ahp", "s3"] }
 pyo3 = "0.23"
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "a3s-code"
-version = "3.6.0"
+version = "3.6.1"
 description = "A3S Code - Native Python bindings for the coding-agent runtime"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Release-engineering fix for **3.6.0**. No library code changes.

## What happened with 3.6.0
Tagging `v3.6.0` published `a3s-code-core` to crates.io ✅, but **all native SDK build jobs failed** → npm / PyPI / GitHub Release were skipped (still at 3.5.0).

Root cause: **brotli 8.0.3** (transitive via `tower-http → async-compression`, required by the `ahp`/`s3` features) no longer compiles on the newest stable Rust — `error[E0277]: StandardAlloc: alloc::Allocator`. It built fine for 3.5.0 a week ago; a new stable landed since. **Not** related to the 3.6.0 feature code. (crates.io's core publish uses default features, which don't pull brotli, so it succeeded.)

## Fix
- **Pin the SDK build toolchain** — `publish-node.yml` / `publish-python.yml` now use `dtolnay/rust-toolchain@1.94.1` (and `maturin-action` `rust-toolchain: 1.94.1`) instead of `@stable` — the known-good toolchain that shipped earlier releases.
- **Refresh `sdk/{node,python}/Cargo.lock`** to `a3s-code-core 3.6.1` (they were stale at 3.5.0, which forced a dep re-resolution that pulled a duplicate `alloc-no-stdlib 3.0.0`). Locks now resolve cleanly: brotli 8.0.3, single alloc-no-stdlib.
- Bump version surface 3.6.0 → 3.6.1.

## Verification
- **Local `cargo check` on both SDK manifests compiles on rustc 1.94.1** (the pinned CI version, with ahp+s3 → brotli) — this is the build CI will now run.
- `cargo fmt --all -- --check` ✅ · `cargo clippy --workspace --lib --bins -- -D warnings` ✅ · `check-version.sh 3.6.1` ✅

Merging this then tagging `v3.6.1` re-runs the release; the SDK builds should now pass and ship npm/PyPI/GH. crates.io will gain `a3s-code-core 3.6.1` (3.6.0 stays as a core-only release).