### PR TITLE
fix(core): relax active skill tool restrictions by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - Unreleased
+
+### Changed
+
+- Active skill `allowed-tools` no longer globally deny ordinary session tool calls
+  by default. Tool calls continue through permission policy, hooks, HITL, and AHP;
+  `SessionOptions::with_active_skill_tool_restrictions(true)` (Node:
+  `enforceActiveSkillToolRestrictions`) restores the legacy global restriction
+  behavior. Skill-local execution still enforces each skill's `allowed-tools`.
+
 ## [4.0.0] - 2026-06-21
 
 Milestone release: **filesystem-first agents**. A single directory

--- a/core/src/agent.rs
+++ b/core/src/agent.rs
@@ -92,6 +92,12 @@ pub(crate) struct AgentConfig {
     pub hook_engine: Option<Arc<dyn HookExecutor>>,
     /// Optional skill registry for tool permission enforcement
     pub skill_registry: Option<Arc<crate::skills::SkillRegistry>>,
+    /// When true, active skill `allowed-tools` restrict ordinary session tool calls.
+    ///
+    /// The default is false: active skills may inject instructions, but ordinary
+    /// tool calls continue to the host permission/AHP/HITL approval chain.
+    /// Skill invocations still enable this for their child execution context.
+    pub enforce_active_skill_tool_restrictions: bool,
     /// Max consecutive malformed-tool-args errors before aborting (default: 2).
     ///
     /// When the LLM returns tool arguments with `__parse_error`, the error is
@@ -181,6 +187,10 @@ impl std::fmt::Debug for AgentConfig {
                 "skill_registry",
                 &self.skill_registry.as_ref().map(|r| r.len()),
             )
+            .field(
+                "enforce_active_skill_tool_restrictions",
+                &self.enforce_active_skill_tool_restrictions,
+            )
             .field("max_parse_retries", &self.max_parse_retries)
             .field("tool_timeout_ms", &self.tool_timeout_ms)
             .field("max_parallel_tasks", &self.max_parallel_tasks)
@@ -221,6 +231,7 @@ impl Default for AgentConfig {
             goal_tracking: false,
             hook_engine: None,
             skill_registry: Some(Arc::new(crate::skills::SkillRegistry::with_builtins())),
+            enforce_active_skill_tool_restrictions: false,
             max_parse_retries: 2,
             tool_timeout_ms: None,
             max_parallel_tasks: DEFAULT_MAX_PARALLEL_TASKS,
@@ -695,6 +706,7 @@ pub struct ToolCommand {
     tool_args: Value,
     tool_context: ToolContext,
     skill_registry: Option<Arc<crate::skills::SkillRegistry>>,
+    enforce_active_skill_tool_restrictions: bool,
 }
 
 impl ToolCommand {
@@ -705,6 +717,7 @@ impl ToolCommand {
         tool_args: Value,
         tool_context: ToolContext,
         skill_registry: Option<Arc<crate::skills::SkillRegistry>>,
+        enforce_active_skill_tool_restrictions: bool,
     ) -> Self {
         Self {
             tool_executor,
@@ -712,6 +725,7 @@ impl ToolCommand {
             tool_args,
             tool_context,
             skill_registry,
+            enforce_active_skill_tool_restrictions,
         }
     }
 }
@@ -720,25 +734,27 @@ impl ToolCommand {
 impl SessionCommand for ToolCommand {
     async fn execute(&self) -> Result<Value> {
         // Check skill-based tool permissions
-        if let Some(registry) = &self.skill_registry {
-            // If there are instruction skills with tool restrictions, check permissions
-            let restricting_skills = registry.global_tool_restricting_skills();
+        if self.enforce_active_skill_tool_restrictions {
+            if let Some(registry) = &self.skill_registry {
+                // If there are instruction skills with tool restrictions, check permissions
+                let restricting_skills = registry.global_tool_restricting_skills();
 
-            if !restricting_skills.is_empty() {
-                let mut allowed = false;
+                if !restricting_skills.is_empty() {
+                    let mut allowed = false;
 
-                for skill in &restricting_skills {
-                    if skill.is_tool_allowed(&self.tool_name) {
-                        allowed = true;
-                        break;
+                    for skill in &restricting_skills {
+                        if skill.is_tool_allowed(&self.tool_name) {
+                            allowed = true;
+                            break;
+                        }
                     }
-                }
 
-                if !allowed {
-                    return Err(anyhow::anyhow!(
+                    if !allowed {
+                        return Err(anyhow::anyhow!(
                         "Tool '{}' is not allowed by any active skill. Active skills restrict tools to their allowed-tools lists.",
                         self.tool_name
                     ));
+                    }
                 }
             }
         }

--- a/core/src/agent/extra_agent_tests.rs
+++ b/core/src/agent/extra_agent_tests.rs
@@ -827,6 +827,7 @@ async fn test_tool_command_command_type() {
         tool_name: "read".to_string(),
         tool_args: serde_json::json!({"file": "test.rs"}),
         skill_registry: None,
+        enforce_active_skill_tool_restrictions: false,
         tool_context: test_tool_context(),
     };
     assert_eq!(cmd.command_type(), "read");
@@ -841,9 +842,75 @@ async fn test_tool_command_payload() {
         tool_name: "read".to_string(),
         tool_args: args.clone(),
         skill_registry: None,
+        enforce_active_skill_tool_restrictions: false,
         tool_context: test_tool_context(),
     };
     assert_eq!(cmd.payload(), args);
+}
+
+#[tokio::test]
+async fn test_tool_command_ignores_active_skill_restrictions_by_default() {
+    let registry = crate::skills::SkillRegistry::new();
+    registry.register_unchecked(Arc::new(crate::skills::Skill {
+        name: "read-only".to_string(),
+        description: String::new(),
+        allowed_tools: Some("read(*)".to_string()),
+        disable_model_invocation: false,
+        kind: crate::skills::SkillKind::Instruction,
+        content: String::new(),
+        tags: Vec::new(),
+        version: None,
+    }));
+
+    let cmd = ToolCommand {
+        tool_executor: Arc::new(ToolExecutor::new("/tmp".to_string())),
+        tool_name: "not_a_tool".to_string(),
+        tool_args: serde_json::json!({}),
+        skill_registry: Some(Arc::new(registry)),
+        enforce_active_skill_tool_restrictions: false,
+        tool_context: test_tool_context(),
+    };
+
+    let output = cmd.execute().await.unwrap();
+    let output = output["output"].as_str().unwrap_or_default();
+    assert!(
+        !output.contains("not allowed by any active skill"),
+        "default mode must let the command reach the tool executor, got: {output}"
+    );
+    assert!(
+        output.contains("Unknown tool"),
+        "default mode should reach the tool executor, got: {output}"
+    );
+}
+
+#[tokio::test]
+async fn test_tool_command_enforces_active_skill_restrictions_in_legacy_mode() {
+    let registry = crate::skills::SkillRegistry::new();
+    registry.register_unchecked(Arc::new(crate::skills::Skill {
+        name: "read-only".to_string(),
+        description: String::new(),
+        allowed_tools: Some("read(*)".to_string()),
+        disable_model_invocation: false,
+        kind: crate::skills::SkillKind::Instruction,
+        content: String::new(),
+        tags: Vec::new(),
+        version: None,
+    }));
+
+    let cmd = ToolCommand {
+        tool_executor: Arc::new(ToolExecutor::new("/tmp".to_string())),
+        tool_name: "not_a_tool".to_string(),
+        tool_args: serde_json::json!({}),
+        skill_registry: Some(Arc::new(registry)),
+        enforce_active_skill_tool_restrictions: true,
+        tool_context: test_tool_context(),
+    };
+
+    let err = cmd.execute().await.unwrap_err().to_string();
+    assert!(
+        err.contains("not allowed by any active skill"),
+        "legacy mode must deny before tool execution, got: {err}"
+    );
 }
 
 // ========================================================================

--- a/core/src/agent/tests.rs
+++ b/core/src/agent/tests.rs
@@ -2032,11 +2032,13 @@ fn parallel_write_batch_only_fast_paths_when_gate_would_execute() {
     fn loop_with(
         checker: Option<Arc<dyn PermissionChecker>>,
         skills: Option<Arc<SkillRegistry>>,
+        enforce_active_skill_tool_restrictions: bool,
     ) -> AgentLoop {
         // `skill_registry` overrides the default builtins where needed.
         let config = AgentConfig {
             permission_checker: checker,
             skill_registry: skills,
+            enforce_active_skill_tool_restrictions,
             ..Default::default()
         };
         AgentLoop::new(
@@ -2052,32 +2054,37 @@ fn parallel_write_batch_only_fast_paths_when_gate_would_execute() {
 
     // Explicit Allow + no restricting skills → fast path is taken.
     assert!(
-        loop_with(allow(), None).can_run_parallel_write_batch(&calls),
+        loop_with(allow(), None, false).can_run_parallel_write_batch(&calls),
         "explicit Allow with no restrictions → parallel write batch is allowed"
     );
 
     // No permission checker → gate resolves to Ask (a Deny without a confirmation
     // manager), so the fast path must be refused.
     assert!(
-        !loop_with(None, None).can_run_parallel_write_batch(&calls),
+        !loop_with(None, None, false).can_run_parallel_write_batch(&calls),
         "missing checker resolves to Ask/Deny → fast path refused"
     );
 
     // Explicit Deny → refused.
     assert!(
-        !loop_with(Some(Arc::new(Static(PermissionDecision::Deny))), None)
-            .can_run_parallel_write_batch(&calls),
+        !loop_with(
+            Some(Arc::new(Static(PermissionDecision::Deny))),
+            None,
+            false
+        )
+        .can_run_parallel_write_batch(&calls),
         "permission Deny → fast path refused"
     );
 
     // Ask → refused (sequential path would need a human round-trip).
     assert!(
-        !loop_with(Some(Arc::new(Static(PermissionDecision::Ask))), None)
+        !loop_with(Some(Arc::new(Static(PermissionDecision::Ask))), None, false)
             .can_run_parallel_write_batch(&calls),
         "permission Ask → fast path refused"
     );
 
-    // Allow, but an active skill restriction forbids write_file → refused.
+    // By default, active skill restrictions do not block ordinary session
+    // tools before the permission/AHP/HITL chain.
     let restricted = SkillRegistry::new();
     restricted.register_unchecked(Arc::new(Skill {
         name: "read-only".to_string(),
@@ -2089,15 +2096,27 @@ fn parallel_write_batch_only_fast_paths_when_gate_would_execute() {
         tags: Vec::new(),
         version: None,
     }));
+    let restricted = Arc::new(restricted);
     assert!(
-        !loop_with(allow(), Some(Arc::new(restricted))).can_run_parallel_write_batch(&calls),
-        "active skill restriction disallowing write_file → fast path refused"
+        loop_with(allow(), Some(Arc::clone(&restricted)), false)
+            .can_run_parallel_write_batch(&calls),
+        "default active skill restriction mode → fast path follows permission allow"
+    );
+
+    // Compatibility mode preserves the legacy refusal.
+    assert!(
+        !loop_with(allow(), Some(restricted), true).can_run_parallel_write_batch(&calls),
+        "legacy active skill restriction mode → fast path refused"
     );
 
     // Default builtins do not restrict → still fast-paths with Allow.
     assert!(
-        loop_with(allow(), Some(Arc::new(SkillRegistry::with_builtins())))
-            .can_run_parallel_write_batch(&calls),
+        loop_with(
+            allow(),
+            Some(Arc::new(SkillRegistry::with_builtins())),
+            false
+        )
+        .can_run_parallel_write_batch(&calls),
         "non-restricting builtins → fast path still allowed"
     );
 }

--- a/core/src/agent/tool_execution_runtime.rs
+++ b/core/src/agent/tool_execution_runtime.rs
@@ -127,6 +127,7 @@ impl AgentLoop {
                 args.clone(),
                 ctx.clone(),
                 self.config.skill_registry.clone(),
+                self.config.enforce_active_skill_tool_restrictions,
             );
             let rx = queue.submit_by_tool(name, Box::new(command)).await;
             match rx.await {

--- a/core/src/agent_api.rs
+++ b/core/src/agent_api.rs
@@ -163,6 +163,12 @@ pub struct SessionOptions {
     pub skill_dirs: Vec<PathBuf>,
     /// Optional skill registry for instruction injection
     pub skill_registry: Option<Arc<crate::skills::SkillRegistry>>,
+    /// Whether active skill `allowed-tools` restrict ordinary session tool calls.
+    ///
+    /// Defaults to false so ordinary tools continue through permission policy,
+    /// hooks, HITL, and AHP. Set true to restore the legacy global active-skill
+    /// restriction behavior.
+    pub enforce_active_skill_tool_restrictions: Option<bool>,
     /// Optional memory store for long-term memory persistence
     pub memory_store: Option<Arc<dyn MemoryStore>>,
     /// Deferred file memory directory — constructed async in `build_session()`

--- a/core/src/agent_api/session_builder.rs
+++ b/core/src/agent_api/session_builder.rs
@@ -155,6 +155,9 @@ pub(super) fn build_agent_session(
         planning_mode: opts.planning_mode,
         goal_tracking: opts.goal_tracking,
         skill_registry: Some(Arc::clone(&effective_registry)),
+        enforce_active_skill_tool_restrictions: opts
+            .enforce_active_skill_tool_restrictions
+            .unwrap_or(base.enforce_active_skill_tool_restrictions),
         max_parse_retries: opts.max_parse_retries.unwrap_or(base.max_parse_retries),
         tool_timeout_ms: opts.tool_timeout_ms.or(base.tool_timeout_ms),
         circuit_breaker_threshold: opts

--- a/core/src/agent_api/session_options.rs
+++ b/core/src/agent_api/session_options.rs
@@ -35,6 +35,10 @@ impl std::fmt::Debug for SessionOptions {
                     .as_ref()
                     .map(|r| format!("{} skills", r.len())),
             )
+            .field(
+                "enforce_active_skill_tool_restrictions",
+                &self.enforce_active_skill_tool_restrictions,
+            )
             .field("memory_store", &self.memory_store.is_some())
             .field("session_store", &self.session_store.is_some())
             .field("session_id", &self.session_id)
@@ -207,6 +211,15 @@ impl SessionOptions {
     /// Add a custom skill registry
     pub fn with_skill_registry(mut self, registry: Arc<crate::skills::SkillRegistry>) -> Self {
         self.skill_registry = Some(registry);
+        self
+    }
+
+    /// Enable or disable legacy global active-skill `allowed-tools` restrictions.
+    ///
+    /// The default is disabled: active skills do not block ordinary session
+    /// tools before the host permission/AHP/HITL approval chain runs.
+    pub fn with_active_skill_tool_restrictions(mut self, enabled: bool) -> Self {
+        self.enforce_active_skill_tool_restrictions = Some(enabled);
         self
     }
 

--- a/core/src/agent_api/session_persistence.rs
+++ b/core/src/agent_api/session_persistence.rs
@@ -170,6 +170,10 @@ pub(super) fn apply_persisted_runtime_options(
             opts = opts.with_permission_policy(policy);
         }
     }
+    if opts.enforce_active_skill_tool_restrictions.is_none() {
+        opts.enforce_active_skill_tool_restrictions =
+            Some(data.config.enforce_active_skill_tool_restrictions);
+    }
     if opts.max_parallel_tasks.is_none() {
         opts.max_parallel_tasks = data.config.max_parallel_tasks;
     }
@@ -271,6 +275,9 @@ async fn build_session_data_snapshot(input: SessionDataSnapshotInput<'_>) -> Ses
             queue_config: input.config.queue_config.clone(),
             confirmation_policy,
             permission_policy: input.config.permission_policy.clone(),
+            enforce_active_skill_tool_restrictions: input
+                .config
+                .enforce_active_skill_tool_restrictions,
             max_parallel_tasks: Some(input.config.max_parallel_tasks),
             auto_delegation: Some(input.config.auto_delegation.clone()),
             parent_id: None,

--- a/core/src/agent_api/tests.rs
+++ b/core/src/agent_api/tests.rs
@@ -2052,7 +2052,8 @@ async fn test_session_save_persists_runtime_config() {
         .with_model("openai/gpt-4o")
         .with_queue_config(queue_config)
         .with_confirmation_policy(confirmation_policy)
-        .with_permission_policy(permission_policy);
+        .with_permission_policy(permission_policy)
+        .with_active_skill_tool_restrictions(true);
     let session = agent
         .session("/tmp/test-ws-runtime-config", Some(opts))
         .unwrap();
@@ -2079,6 +2080,7 @@ async fn test_session_save_persists_runtime_config() {
         .permission_policy
         .as_ref()
         .is_some_and(|p| !p.allow.is_empty()));
+    assert!(data.config.enforce_active_skill_tool_restrictions);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2095,7 +2097,8 @@ async fn test_resume_session_restores_runtime_config() {
         .with_model("openai/gpt-4o")
         .with_queue_config(queue_config)
         .with_confirmation_policy(confirmation_policy)
-        .with_permission_policy(permission_policy);
+        .with_permission_policy(permission_policy)
+        .with_active_skill_tool_restrictions(true);
     let session = agent
         .session("/tmp/test-ws-resume-runtime", Some(opts))
         .unwrap();
@@ -2112,6 +2115,7 @@ async fn test_resume_session_restores_runtime_config() {
     assert!(resumed.config.confirmation_manager.is_some());
     assert!(resumed.config.permission_policy.is_some());
     assert!(resumed.config.permission_checker.is_some());
+    assert!(resumed.config.enforce_active_skill_tool_restrictions);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -2621,14 +2625,38 @@ async fn test_session_options_builders() {
         .with_auto_save(true)
         .with_max_parallel_tasks(3)
         .with_auto_delegation_enabled(true)
-        .with_auto_parallel_delegation(false);
+        .with_auto_parallel_delegation(false)
+        .with_active_skill_tool_restrictions(true);
     assert_eq!(opts.session_id, Some("test-id".to_string()));
     assert!(opts.auto_save);
     assert_eq!(opts.max_parallel_tasks, Some(3));
     assert_eq!(opts.auto_parallel_delegation, Some(false));
+    assert_eq!(opts.enforce_active_skill_tool_restrictions, Some(true));
     let auto = opts.auto_delegation.expect("auto delegation config");
     assert!(auto.enabled);
     assert!(!auto.auto_parallel);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_active_skill_tool_restriction_option_defaults_and_overrides() {
+    let agent = Agent::from_config(test_config()).await.unwrap();
+
+    let default_session = agent
+        .session("/tmp/test-ws-skill-restriction-default", None)
+        .unwrap();
+    assert!(
+        !default_session
+            .config
+            .enforce_active_skill_tool_restrictions
+    );
+
+    let legacy_session = agent
+        .session(
+            "/tmp/test-ws-skill-restriction-legacy",
+            Some(SessionOptions::new().with_active_skill_tool_restrictions(true)),
+        )
+        .unwrap();
+    assert!(legacy_session.config.enforce_active_skill_tool_restrictions);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/core/src/safety_gate.rs
+++ b/core/src/safety_gate.rs
@@ -102,6 +102,10 @@ impl<'a> ToolSafetyGate<'a> {
     }
 
     pub(crate) fn check_skill_restrictions(&self, tool_name: &str) -> Option<ToolGateDecision> {
+        if !self.config.enforce_active_skill_tool_restrictions {
+            return None;
+        }
+
         let registry = self.config.skill_registry.as_ref()?;
         let restricting_skills = registry.global_tool_restricting_skills();
         if restricting_skills.is_empty() {
@@ -198,7 +202,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn skill_restriction_denies_before_permission_allow() {
+    async fn active_skill_restriction_is_ignored_by_default_before_permission_allow() {
         let config = AgentConfig {
             skill_registry: Some(restricted_registry()),
             permission_checker: Some(Arc::new(StaticPermission(PermissionDecision::Allow))),
@@ -216,8 +220,60 @@ mod tests {
 
         assert!(matches!(
             decision,
+            ToolGateDecision::Execute {
+                reason: ToolGateApproval::PermissionAllow,
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn active_skill_restriction_denies_when_legacy_mode_is_enabled() {
+        let config = AgentConfig {
+            skill_registry: Some(restricted_registry()),
+            enforce_active_skill_tool_restrictions: true,
+            permission_checker: Some(Arc::new(StaticPermission(PermissionDecision::Allow))),
+            ..Default::default()
+        };
+        let gate = ToolSafetyGate::new(&config);
+
+        let decision = gate
+            .decide(ToolGateInput {
+                tool_name: "write",
+                args: &json!({"file_path": "x"}),
+                pre_tool_block: None,
+            })
+            .await;
+
+        assert!(matches!(
+            decision,
             ToolGateDecision::Deny {
                 reason: ToolGateDenial::SkillRestriction,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn ignored_active_skill_restriction_still_allows_permission_deny() {
+        let config = AgentConfig {
+            skill_registry: Some(restricted_registry()),
+            permission_checker: Some(Arc::new(StaticPermission(PermissionDecision::Deny))),
+            ..Default::default()
+        };
+        let gate = ToolSafetyGate::new(&config);
+
+        let decision = gate
+            .decide(ToolGateInput {
+                tool_name: "write",
+                args: &json!({"file_path": "x"}),
+                pre_tool_block: None,
+            })
+            .await;
+
+        assert!(matches!(
+            decision,
+            ToolGateDecision::Deny {
+                reason: ToolGateDenial::PermissionDeny,
                 ..
             }
         ));

--- a/core/src/skills/mod.rs
+++ b/core/src/skills/mod.rs
@@ -243,9 +243,9 @@ impl Skill {
         }
 
         // Check if any permission matches
-        permissions
-            .iter()
-            .any(|perm| perm.tool.eq_ignore_ascii_case(tool_name) && perm.pattern == "*")
+        permissions.iter().any(|perm| {
+            (perm.tool == "*" || perm.tool.eq_ignore_ascii_case(tool_name)) && perm.pattern == "*"
+        })
     }
 
     /// Get the skill content formatted for injection into system prompt
@@ -420,6 +420,24 @@ allowed-tools:
         assert!(skill.is_tool_allowed("read"));
         assert!(skill.is_tool_allowed("grep"));
         assert!(!skill.is_tool_allowed("write"));
+    }
+
+    #[test]
+    fn test_wildcard_allowed_tools_allows_any_tool() {
+        let skill = Skill {
+            name: "test".to_string(),
+            description: "test".to_string(),
+            allowed_tools: Some("*".to_string()),
+            disable_model_invocation: false,
+            kind: SkillKind::Instruction,
+            content: String::new(),
+            tags: Vec::new(),
+            version: None,
+        };
+
+        assert!(skill.is_tool_allowed("read"));
+        assert!(skill.is_tool_allowed("bash"));
+        assert!(skill.is_tool_allowed("parallel_task"));
     }
 
     #[test]

--- a/core/src/store/session_data.rs
+++ b/core/src/store/session_data.rs
@@ -46,6 +46,10 @@ pub(crate) fn default_auto_compact_threshold() -> f32 {
     DEFAULT_AUTO_COMPACT_THRESHOLD
 }
 
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 /// Serializable session configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionConfig {
@@ -73,6 +77,9 @@ pub struct SessionConfig {
     /// Permission policy (optional, uses defaults if None).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub permission_policy: Option<crate::permissions::PermissionPolicy>,
+    /// Whether active skill `allowed-tools` restrict ordinary session tools.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub enforce_active_skill_tool_restrictions: bool,
     /// Maximum sibling branches/tools to run concurrently.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_parallel_tasks: Option<usize>,
@@ -109,6 +116,7 @@ impl Default for SessionConfig {
             queue_config: None,
             confirmation_policy: None,
             permission_policy: None,
+            enforce_active_skill_tool_restrictions: false,
             max_parallel_tasks: None,
             auto_delegation: None,
             parent_id: None,

--- a/core/src/store/tests.rs
+++ b/core/src/store/tests.rs
@@ -24,6 +24,7 @@ fn create_test_session_data() -> SessionData {
             queue_config: None,
             confirmation_policy: None,
             permission_policy: None,
+            enforce_active_skill_tool_restrictions: false,
             max_parallel_tasks: None,
             auto_delegation: None,
             parent_id: None,
@@ -429,6 +430,7 @@ async fn test_file_store_with_policies() {
     session.config.confirmation_policy = Some(ConfirmationPolicy::enabled());
     session.config.permission_policy = Some(PermissionPolicy::new().allow("Bash(cargo:*)"));
     session.config.queue_config = Some(SessionQueueConfig::default());
+    session.config.enforce_active_skill_tool_restrictions = true;
 
     store.save(&session).await.unwrap();
 
@@ -436,6 +438,7 @@ async fn test_file_store_with_policies() {
     assert!(loaded.config.confirmation_policy.is_some());
     assert!(loaded.config.permission_policy.is_some());
     assert!(loaded.config.queue_config.is_some());
+    assert!(loaded.config.enforce_active_skill_tool_restrictions);
 }
 
 #[tokio::test]

--- a/core/src/tools/skill.rs
+++ b/core/src/tools/skill.rs
@@ -319,6 +319,7 @@ The skill's allowed-tools are granted during execution and revoked after complet
 
         // Set the skill's permission policy as the permission checker
         skill_config.permission_checker = Some(Arc::new(skill_permission_policy));
+        skill_config.enforce_active_skill_tool_restrictions = true;
 
         // Create a temporary skill registry with only this skill
         let temp_registry = Arc::new(SkillRegistry::new());
@@ -514,6 +515,31 @@ mod tests {
         assert_eq!(
             policy.check("grep", &serde_json::json!({"pattern": "x"})),
             PermissionDecision::Deny
+        );
+    }
+
+    #[test]
+    fn test_skill_permission_policy_accepts_wildcard_allowed_tools() {
+        let skill = Skill {
+            name: "test-skill".to_string(),
+            description: "Test".to_string(),
+            allowed_tools: Some("*".to_string()),
+            disable_model_invocation: false,
+            kind: SkillKind::Instruction,
+            content: String::new(),
+            tags: Vec::new(),
+            version: None,
+        };
+
+        let policy = SkillTool::create_skill_permission_policy(&skill);
+
+        assert_eq!(
+            policy.check("bash", &serde_json::json!({"command": "python --version"})),
+            PermissionDecision::Allow
+        );
+        assert_eq!(
+            policy.check("parallel_task", &serde_json::json!({"tasks": []})),
+            PermissionDecision::Allow
         );
     }
 

--- a/sdk/node/generated.d.ts
+++ b/sdk/node/generated.d.ts
@@ -413,6 +413,13 @@ export interface SessionOptions {
   builtinSkills?: boolean
   /** Extra directories to scan for skill files (.md with YAML frontmatter). */
   skillDirs?: Array<string>
+  /**
+   * Whether active skill allowed-tools restrict ordinary session tool calls.
+   *
+   * Defaults to false. Set true to restore the legacy global active-skill
+   * restriction before permission policy, hooks, HITL, or AHP run.
+   */
+  enforceActiveSkillToolRestrictions?: boolean
   /** Extra directories to scan for agent files. */
   agentDirs?: Array<string>
   /** Reproducible disposable workers to register for task delegation. */

--- a/sdk/node/src/lib.rs
+++ b/sdk/node/src/lib.rs
@@ -1783,6 +1783,11 @@ pub struct SessionOptions {
     pub builtin_skills: Option<bool>,
     /// Extra directories to scan for skill files (.md with YAML frontmatter).
     pub skill_dirs: Option<Vec<String>>,
+    /// Whether active skill allowed-tools restrict ordinary session tool calls.
+    ///
+    /// Defaults to false. Set true to restore the legacy global active-skill
+    /// restriction before permission policy, hooks, HITL, or AHP run.
+    pub enforce_active_skill_tool_restrictions: Option<bool>,
     /// Extra directories to scan for agent files.
     pub agent_dirs: Option<Vec<String>>,
     /// Reproducible disposable workers to register for task delegation.
@@ -2302,6 +2307,9 @@ fn js_session_options_to_rust(options: Option<SessionOptions>) -> napi::Result<R
         for d in dirs {
             opts = opts.with_skills_from_dir(d);
         }
+    }
+    if let Some(enabled) = o.enforce_active_skill_tool_restrictions {
+        opts = opts.with_active_skill_tool_restrictions(enabled);
     }
     if let Some(dirs) = o.agent_dirs {
         for d in dirs {
@@ -6047,6 +6055,25 @@ mod tests {
         assert!(!auto.auto_parallel);
         assert!((auto.min_confidence - 0.8).abs() < f32::EPSILON);
         assert_eq!(auto.max_tasks, 2);
+    }
+
+    #[test]
+    fn session_options_maps_active_skill_tool_restriction_control() {
+        let default_opts = js_session_options_to_rust(Some(SessionOptions {
+            ..Default::default()
+        }))
+        .unwrap();
+        assert_eq!(default_opts.enforce_active_skill_tool_restrictions, None);
+
+        let legacy_opts = js_session_options_to_rust(Some(SessionOptions {
+            enforce_active_skill_tool_restrictions: Some(true),
+            ..Default::default()
+        }))
+        .unwrap();
+        assert_eq!(
+            legacy_opts.enforce_active_skill_tool_restrictions,
+            Some(true)
+        );
     }
 
     #[test]

--- a/sdk/node/src/lib.rs
+++ b/sdk/node/src/lib.rs
@@ -42,6 +42,7 @@ mod js_slash_command;
 use js_slash_command::{js_command_context_to_object, JsSlashCommand};
 
 use a3s_code_core::commands::CommandContext as RustCommandContext;
+use a3s_code_core::config::AgentDir as RustAgentDir;
 use a3s_code_core::config::{
     BrowserBackend as RustBrowserBackend, HeadlessConfig as RustHeadlessConfig,
     SearchConfig as RustSearchConfig, SearchEngineConfig as RustSearchEngineConfig,
@@ -70,6 +71,7 @@ use a3s_code_core::queue::{
     MetricsSnapshot as RustMetricsSnapshot, SessionLane as RustSessionLane,
     SessionQueueConfig as RustSessionQueueConfig, TaskHandlerMode as RustTaskHandlerMode,
 };
+use a3s_code_core::serve::serve_agent_dir as rust_serve_agent_dir;
 use a3s_code_core::skills::{builtin_skills as rust_builtin_skills, SkillKind as RustSkillKind};
 use a3s_code_core::subagent::{
     AgentDefinition as RustAgentDefinition, ModelConfig as RustAgentModelConfig,
@@ -80,8 +82,6 @@ use a3s_code_core::verification::{
     VerificationCommand as RustVerificationCommand, VerificationReport as RustVerificationReport,
     VerificationStatus as RustVerificationStatus, VerificationSummary as RustVerificationSummary,
 };
-use a3s_code_core::config::AgentDir as RustAgentDir;
-use a3s_code_core::serve::serve_agent_dir as rust_serve_agent_dir;
 use a3s_code_core::{
     Agent as RustAgent, AgentEvent as RustAgentEvent, AgentResult as RustAgentResult,
     AgentSession as RustAgentSession, PlanningMode as RustPlanningMode,

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -1112,8 +1112,7 @@ impl PyAgent {
             // serve_agent_dir returns Result and never panics by construction; a
             // scheduling error is reported, not propagated (spawned task bodies
             // are not panic-safe).
-            if let Err(e) =
-                rust_serve_agent_dir(&agent, &agent_dir, workspace, extra, cancel).await
+            if let Err(e) = rust_serve_agent_dir(&agent, &agent_dir, workspace, extra, cancel).await
             {
                 eprintln!("a3s-code: serve_agent_dir daemon exited with error: {e}");
             }

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -4824,6 +4824,7 @@ struct PySessionOptions {
     model: Option<String>,
     builtin_skills: bool,
     skill_dirs: Vec<String>,
+    enforce_active_skill_tool_restrictions: Option<bool>,
     agent_dirs: Vec<String>,
     worker_agents: Vec<PyWorkerAgentSpec>,
     queue_config: Option<PySessionQueueConfig>,
@@ -4967,6 +4968,7 @@ impl Clone for PySessionOptions {
             model: self.model.clone(),
             builtin_skills: self.builtin_skills,
             skill_dirs: self.skill_dirs.clone(),
+            enforce_active_skill_tool_restrictions: self.enforce_active_skill_tool_restrictions,
             agent_dirs: self.agent_dirs.clone(),
             worker_agents: self.worker_agents.clone(),
             queue_config: self.queue_config.clone(),
@@ -5035,6 +5037,7 @@ impl PySessionOptions {
             model: None,
             builtin_skills: false,
             skill_dirs: vec![],
+            enforce_active_skill_tool_restrictions: None,
             agent_dirs: vec![],
             worker_agents: vec![],
             queue_config: None,
@@ -5111,6 +5114,20 @@ impl PySessionOptions {
     #[setter]
     fn set_skill_dirs(&mut self, value: Vec<String>) {
         self.skill_dirs = value;
+    }
+
+    /// Whether active skill allowed-tools restrict ordinary session tool calls.
+    ///
+    /// Defaults to None/False. Set True to restore the legacy global
+    /// active-skill restriction before permission policy, hooks, HITL, or AHP run.
+    #[getter]
+    fn get_enforce_active_skill_tool_restrictions(&self) -> Option<bool> {
+        self.enforce_active_skill_tool_restrictions
+    }
+
+    #[setter]
+    fn set_enforce_active_skill_tool_restrictions(&mut self, value: Option<bool>) {
+        self.enforce_active_skill_tool_restrictions = value;
     }
 
     /// Extra directories to scan for agent files.
@@ -5869,6 +5886,9 @@ fn build_rust_session_options(so: PySessionOptions) -> PyResult<RustSessionOptio
     }
     for d in &so.skill_dirs {
         o = o.with_skills_from_dir(d);
+    }
+    if let Some(enabled) = so.enforce_active_skill_tool_restrictions {
+        o = o.with_active_skill_tool_restrictions(enabled);
     }
     for d in &so.agent_dirs {
         o = o.with_agent_dir(d);
@@ -7002,6 +7022,18 @@ mod tests {
         assert!(!auto.auto_parallel);
         assert!((auto.min_confidence - 0.8).abs() < f32::EPSILON);
         assert_eq!(auto.max_tasks, 2);
+    }
+
+    #[test]
+    fn session_options_map_active_skill_tool_restriction_control() {
+        let default_opts = build_rust_session_options(PySessionOptions::new()).unwrap();
+        assert_eq!(default_opts.enforce_active_skill_tool_restrictions, None);
+
+        let mut session_options = PySessionOptions::new();
+        session_options.enforce_active_skill_tool_restrictions = Some(true);
+
+        let opts = build_rust_session_options(session_options).unwrap();
+        assert_eq!(opts.enforce_active_skill_tool_restrictions, Some(true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Stop active skill `allowed-tools` from globally denying ordinary session tool calls by default.
- Add `enforceActiveSkillToolRestrictions` / `with_active_skill_tool_restrictions(true)` as a compatibility switch for legacy behavior.
- Keep skill-local `allowed-tools` enforced inside `Skill` child execution contexts.
- Treat `allowed-tools: "*"` as a skill grant wildcard without bypassing permission policy, hooks, HITL, or AHP.

## Tests

- `cargo fmt --all -- --check`
- `rustfmt --edition 2021 --check sdk/node/src/lib.rs sdk/python/src/lib.rs`
- `git diff --check`
- `cargo test -p a3s-code-core`
- `cargo test --manifest-path sdk/node/Cargo.toml`
- `cargo test --manifest-path sdk/python/Cargo.toml`