### PR TITLE
feat(serve): filesystem-first agents (eve parity) — agent-dir, cron schedules, serve daemon, tools/

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "bytes",
  "cfb",
  "chrono",
+ "cron",
  "dirs",
  "flate2",
  "futures",
@@ -1311,6 +1312,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -102,6 +102,8 @@ uuid = { version = "1.6", features = ["v4", "serde"] }
 
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }
+# Cron parsing for the `serve` schedules (gated behind the `serve` feature).
+cron = { version = "0.12", optional = true }
 rquickjs = { version = "0.11.0", features = ["futures"] }
 
 # S3-compatible workspace backend (optional, gated by `s3` feature)
@@ -137,6 +139,9 @@ s3 = [
     "dep:aws-smithy-types",
     "dep:aws-smithy-runtime-api",
 ]
+# Enable the durable serve layer: cron schedules + (later) channels + serve daemon
+# for filesystem-first agents. Library-only embedders pay nothing without it.
+serve = ["dep:cron"]
 
 [dev-dependencies]
 # AHP for integration tests

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -152,3 +152,5 @@ wiremock = "0.6"
 # Self-signed cert generation for mTLS happy-path tests. Production code does
 # not depend on rcgen.
 rcgen = "0.13"
+# Implement the async ScheduleSink trait in serve integration tests.
+async-trait = "0.1"

--- a/core/src/config/agent_dir.rs
+++ b/core/src/config/agent_dir.rs
@@ -1,0 +1,318 @@
+//! Filesystem-first agent directory convention (eve-style, harness-respecting).
+//!
+//! A single directory defines a durable agent by convention:
+//!
+//! ```text
+//! agent/
+//! ├── instructions.md   (required)  role/guidelines — injected as a prompt SLOT,
+//! │                                 NOT a system-prompt override, so the harness
+//! │                                 keeps BOUNDARIES, response-format, and
+//! │                                 verification authoritative.
+//! ├── agent.acl          (optional)  model/providers/queue (CodeConfig). Default if absent.
+//! ├── skills/            (optional)  *.md skills, appended to CodeConfig.skill_dirs.
+//! ├── schedules/         (optional)  *.md cron jobs (YAML frontmatter `cron:` + body=prompt).
+//! ├── channels/          (optional)  *.{md,acl} inbound adapters — parsed here, served later.
+//! └── tools/             (optional)  reserved → MCP / sandboxed declarative tools.
+//! ```
+//!
+//! [`AgentDir::load`] SYNTHESIZES existing config objects rather than adding a new
+//! runtime: `instructions.md` → [`SystemPromptSlots`], `agent.acl` → [`CodeConfig`],
+//! `skills/` → `skill_dirs`. Tool definition, visibility, and safety stay
+//! harness-owned (the deliberate divergence from eve's user-defined-tools model).
+
+use std::path::{Path, PathBuf};
+
+use crate::config::CodeConfig;
+use crate::error::{CodeError, Result};
+use crate::prompts::SystemPromptSlots;
+
+/// A cron-triggered recurring turn, parsed from `schedules/<name>.md`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScheduleSpec {
+    /// Schedule name (frontmatter `name`, else the file stem).
+    pub name: String,
+    /// Cron expression (validated/executed by the serve layer).
+    pub cron: String,
+    /// Markdown prompt sent into a turn on each fire (the file body).
+    pub prompt: String,
+    /// Whether the schedule is active (frontmatter `enabled`, default true).
+    pub enabled: bool,
+}
+
+/// An inbound channel adapter spec, parsed from `channels/<name>.{md,acl}`.
+///
+/// Parsed so the directory convention is complete; the serve layer does not yet
+/// implement adapters (channels are design-only for now). `frontmatter` carries
+/// the raw adapter options for whichever adapter eventually handles `kind`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChannelSpec {
+    /// Channel name (frontmatter `name`, else the file stem).
+    pub name: String,
+    /// Adapter kind: `http`, `slack`, `discord`, …
+    pub kind: String,
+    /// Raw frontmatter (YAML) for the adapter to interpret.
+    pub frontmatter: String,
+}
+
+/// A loaded agent directory: synthesized [`CodeConfig`] + prompt slots + parsed
+/// schedule/channel specs. Build a session from `config` + `prompt_slots`.
+///
+/// Distinct from [`CodeConfig::agent_dirs`](crate::config::CodeConfig) /
+/// `register_agent_dir`, which scan a directory for **worker/subagent**
+/// definitions. An `AgentDir` is the eve-style *primary* agent — the directory
+/// that defines this agent's prompt, skills, schedules, and channels.
+#[derive(Debug, Clone)]
+pub struct AgentDir {
+    pub dir: PathBuf,
+    pub config: CodeConfig,
+    pub prompt_slots: SystemPromptSlots,
+    pub schedules: Vec<ScheduleSpec>,
+    pub channels: Vec<ChannelSpec>,
+}
+
+impl AgentDir {
+    /// Load an agent directory by convention. `instructions.md` is required.
+    pub fn load(dir: impl AsRef<Path>) -> Result<Self> {
+        let dir = dir.as_ref().to_path_buf();
+        if !dir.is_dir() {
+            return Err(CodeError::Context(format!(
+                "agent directory not found: {}",
+                dir.display()
+            )));
+        }
+
+        // instructions.md (required) → role SLOT. Using a slot (not a raw system
+        // prompt) keeps the harness's BOUNDARIES/response-format/verification.
+        let instructions = std::fs::read_to_string(dir.join("instructions.md")).map_err(|e| {
+            CodeError::Context(format!(
+                "agent dir {} is missing required instructions.md: {e}",
+                dir.display()
+            ))
+        })?;
+        let prompt_slots = SystemPromptSlots {
+            role: Some(instructions.trim().to_string()),
+            ..Default::default()
+        };
+
+        // agent.acl (optional) → CodeConfig, else default.
+        let acl_path = dir.join("agent.acl");
+        let mut config = if acl_path.is_file() {
+            CodeConfig::from_file(&acl_path)?
+        } else {
+            CodeConfig::default()
+        };
+
+        // skills/ → appended to skill_dirs (existing *.md format, zero adaptation).
+        let skills_dir = dir.join("skills");
+        if skills_dir.is_dir() {
+            config.skill_dirs.push(skills_dir);
+        }
+
+        let schedules = load_schedules(&dir.join("schedules"))?;
+        let channels = load_channels(&dir.join("channels"))?;
+
+        Ok(Self {
+            dir,
+            config,
+            prompt_slots,
+            schedules,
+            channels,
+        })
+    }
+}
+
+/// Markdown files with a `<ext>` extension in `dir`, sorted by path. Returns an
+/// empty list when `dir` does not exist.
+fn md_files(dir: &Path, exts: &[&str]) -> Result<Vec<PathBuf>> {
+    if !dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(dir)
+        .map_err(|e| CodeError::Context(format!("read {}: {e}", dir.display())))?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| {
+            p.extension()
+                .and_then(|s| s.to_str())
+                .map(|e| exts.contains(&e))
+                .unwrap_or(false)
+        })
+        .collect();
+    entries.sort();
+    Ok(entries)
+}
+
+fn load_schedules(dir: &Path) -> Result<Vec<ScheduleSpec>> {
+    let mut out = Vec::new();
+    for path in md_files(dir, &["md"])? {
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| CodeError::Context(format!("read {}: {e}", path.display())))?;
+        let (front, body) = split_frontmatter(&content);
+        let front = front.ok_or_else(|| {
+            CodeError::Context(format!(
+                "schedule {} has no YAML frontmatter (need `cron:`)",
+                path.display()
+            ))
+        })?;
+        let meta: ScheduleFront = serde_yaml::from_str(&front).map_err(|e| {
+            CodeError::Context(format!("schedule {} frontmatter: {e}", path.display()))
+        })?;
+        out.push(ScheduleSpec {
+            name: meta.name.unwrap_or_else(|| file_stem(&path)),
+            cron: meta.cron,
+            prompt: body.trim().to_string(),
+            enabled: meta.enabled.unwrap_or(true),
+        });
+    }
+    Ok(out)
+}
+
+fn load_channels(dir: &Path) -> Result<Vec<ChannelSpec>> {
+    let mut out = Vec::new();
+    for path in md_files(dir, &["md", "acl"])? {
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| CodeError::Context(format!("read {}: {e}", path.display())))?;
+        let (front, _body) = split_frontmatter(&content);
+        let front = front.ok_or_else(|| {
+            CodeError::Context(format!(
+                "channel {} has no frontmatter (need `kind:`)",
+                path.display()
+            ))
+        })?;
+        let meta: ChannelFront = serde_yaml::from_str(&front).map_err(|e| {
+            CodeError::Context(format!("channel {} frontmatter: {e}", path.display()))
+        })?;
+        out.push(ChannelSpec {
+            name: meta.name.unwrap_or_else(|| file_stem(&path)),
+            kind: meta.kind,
+            frontmatter: front,
+        });
+    }
+    Ok(out)
+}
+
+fn file_stem(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unnamed")
+        .to_string()
+}
+
+/// Split a leading `---\n…\n---` YAML frontmatter block from the markdown body.
+/// Returns `(None, whole)` when there is no frontmatter.
+fn split_frontmatter(content: &str) -> (Option<String>, String) {
+    let trimmed = content.trim_start();
+    if let Some(rest) = trimmed.strip_prefix("---") {
+        let rest = rest.trim_start_matches(['\r', '\n']);
+        // Closing fence: a line that is exactly `---`.
+        for marker in ["\n---\n", "\n---\r\n", "\n---"] {
+            if let Some(end) = rest.find(marker) {
+                let front = rest[..end].to_string();
+                let body = rest[end + marker.len()..]
+                    .trim_start_matches(['\r', '\n'])
+                    .to_string();
+                return (Some(front), body);
+            }
+        }
+    }
+    (None, content.to_string())
+}
+
+#[derive(serde::Deserialize)]
+struct ScheduleFront {
+    cron: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    enabled: Option<bool>,
+}
+
+#[derive(serde::Deserialize)]
+struct ChannelFront {
+    kind: String,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a fixture agent dir under a unique temp path.
+    fn fixture() -> PathBuf {
+        let base = std::env::temp_dir().join(format!("a3s-agentdir-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(base.join("skills")).unwrap();
+        std::fs::create_dir_all(base.join("schedules")).unwrap();
+        std::fs::create_dir_all(base.join("channels")).unwrap();
+        std::fs::write(
+            base.join("instructions.md"),
+            "You are a release-notes agent. Be terse and accurate.",
+        )
+        .unwrap();
+        std::fs::write(
+            base.join("skills/summarize.md"),
+            "---\nname: summarize\ndescription: summarize text\n---\n# Summarize\n",
+        )
+        .unwrap();
+        std::fs::write(
+            base.join("schedules/daily.md"),
+            "---\ncron: \"0 9 * * *\"\nname: daily-report\n---\nGenerate the daily report and post it.\n",
+        )
+        .unwrap();
+        std::fs::write(
+            base.join("channels/web.md"),
+            "---\nkind: http\nport: 8787\n---\nInbound HTTP channel.\n",
+        )
+        .unwrap();
+        base
+    }
+
+    #[test]
+    fn loads_convention_into_slots_and_specs() {
+        let dir = fixture();
+        let agent = AgentDir::load(&dir).unwrap();
+
+        // instructions.md → role SLOT (not a raw system-prompt override).
+        assert_eq!(
+            agent.prompt_slots.role.as_deref(),
+            Some("You are a release-notes agent. Be terse and accurate.")
+        );
+
+        // skills/ → appended to skill_dirs.
+        assert!(agent
+            .config
+            .skill_dirs
+            .iter()
+            .any(|p| p.ends_with("skills")));
+
+        // schedules/*.md → parsed cron + body prompt.
+        assert_eq!(agent.schedules.len(), 1);
+        let s = &agent.schedules[0];
+        assert_eq!(s.name, "daily-report");
+        assert_eq!(s.cron, "0 9 * * *");
+        assert_eq!(s.prompt, "Generate the daily report and post it.");
+        assert!(s.enabled);
+
+        // channels/*.md → parsed kind (adapters not yet implemented).
+        assert_eq!(agent.channels.len(), 1);
+        assert_eq!(agent.channels[0].kind, "http");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_instructions_is_an_error() {
+        let base = std::env::temp_dir().join(format!("a3s-agentdir-empty-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(&base).unwrap();
+        assert!(AgentDir::load(&base).is_err());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn frontmatter_split_handles_no_frontmatter() {
+        let (f, b) = split_frontmatter("no frontmatter here");
+        assert!(f.is_none());
+        assert_eq!(b, "no frontmatter here");
+    }
+}

--- a/core/src/config/agent_dir.rs
+++ b/core/src/config/agent_dir.rs
@@ -12,7 +12,9 @@
 //! ├── skills/            (optional)  *.md skills, appended to CodeConfig.skill_dirs.
 //! ├── schedules/         (optional)  *.md cron jobs (YAML frontmatter `cron:` + body=prompt).
 //! ├── channels/          (optional)  *.{md,acl} inbound adapters — parsed here, served later.
-//! └── tools/             (optional)  reserved → MCP / sandboxed declarative tools.
+//! └── tools/             (optional)  *.md tool specs (`kind: mcp`) → MCP servers
+//! │                                 registered into the session (sandboxed-script
+//! │                                 `kind` is the next increment).
 //! ```
 //!
 //! [`AgentDir::load`] SYNTHESIZES existing config objects rather than adding a new
@@ -24,6 +26,7 @@ use std::path::{Path, PathBuf};
 
 use crate::config::CodeConfig;
 use crate::error::{CodeError, Result};
+use crate::mcp::McpServerConfig;
 use crate::prompts::SystemPromptSlots;
 
 /// A cron-triggered recurring turn, parsed from `schedules/<name>.md`.
@@ -54,6 +57,36 @@ pub struct ChannelSpec {
     pub frontmatter: String,
 }
 
+/// A tool definition parsed from `tools/<name>.md`, dispatched by `kind`.
+///
+/// Tool *definition* may come from the directory, but visibility and safety stay
+/// harness-owned (the deliberate divergence from eve): an `mcp` spec is registered
+/// through the normal [`add_mcp_server`](crate::AgentSession) path, so its tools
+/// are namespaced `mcp__<server>__<tool>` and gated by the session's permission
+/// policy like any other tool.
+#[derive(Debug, Clone)]
+pub enum ToolSpec {
+    /// `kind = "mcp"` → an MCP server connected into the session, contributing its
+    /// `list_tools()` as `mcp__<name>__*` tools.
+    Mcp(McpServerConfig),
+}
+
+impl ToolSpec {
+    /// The tool/server name (registry key; unique within `tools/`).
+    pub fn name(&self) -> &str {
+        match self {
+            ToolSpec::Mcp(cfg) => &cfg.name,
+        }
+    }
+
+    /// The spec kind discriminant (currently only `mcp`).
+    pub fn kind(&self) -> &str {
+        match self {
+            ToolSpec::Mcp(_) => "mcp",
+        }
+    }
+}
+
 /// A loaded agent directory: synthesized [`CodeConfig`] + prompt slots + parsed
 /// schedule/channel specs. Build a session from `config` + `prompt_slots`.
 ///
@@ -68,6 +101,7 @@ pub struct AgentDir {
     pub prompt_slots: SystemPromptSlots,
     pub schedules: Vec<ScheduleSpec>,
     pub channels: Vec<ChannelSpec>,
+    pub tools: Vec<ToolSpec>,
 }
 
 impl AgentDir {
@@ -110,6 +144,7 @@ impl AgentDir {
 
         let schedules = load_schedules(&dir.join("schedules"))?;
         let channels = load_channels(&dir.join("channels"))?;
+        let tools = load_tools(&dir.join("tools"))?;
 
         Ok(Self {
             dir,
@@ -117,6 +152,7 @@ impl AgentDir {
             prompt_slots,
             schedules,
             channels,
+            tools,
         })
     }
 }
@@ -190,6 +226,53 @@ fn load_channels(dir: &Path) -> Result<Vec<ChannelSpec>> {
     Ok(out)
 }
 
+fn load_tools(dir: &Path) -> Result<Vec<ToolSpec>> {
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for path in md_files(dir, &["md"])? {
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| CodeError::Context(format!("read {}: {e}", path.display())))?;
+        let (front, _body) = split_frontmatter(&content);
+        let front = front.ok_or_else(|| {
+            CodeError::Context(format!(
+                "tool {} has no YAML frontmatter (need `kind:`)",
+                path.display()
+            ))
+        })?;
+        let meta: ToolFront = serde_yaml::from_str(&front)
+            .map_err(|e| CodeError::Context(format!("tool {} frontmatter: {e}", path.display())))?;
+        let spec = match meta.kind.as_str() {
+            "mcp" => {
+                // The frontmatter's flat fields (transport/command/args/url/…) plus
+                // `name` deserialize straight into McpServerConfig; the `kind` key is
+                // ignored by its lenient Deserialize.
+                let cfg: McpServerConfig = serde_yaml::from_str(&front).map_err(|e| {
+                    CodeError::Context(format!(
+                        "tool {} (kind=mcp) is not a valid MCP server config: {e}",
+                        path.display()
+                    ))
+                })?;
+                ToolSpec::Mcp(cfg)
+            }
+            other => {
+                return Err(CodeError::Context(format!(
+                    "tool {} has unsupported kind `{other}` (supported: `mcp`)",
+                    path.display()
+                )));
+            }
+        };
+        if !seen.insert(spec.name().to_string()) {
+            return Err(CodeError::Context(format!(
+                "duplicate tool name `{}` in {}",
+                spec.name(),
+                path.display()
+            )));
+        }
+        out.push(spec);
+    }
+    Ok(out)
+}
+
 fn file_stem(path: &Path) -> String {
     path.file_stem()
         .and_then(|s| s.to_str())
@@ -233,6 +316,11 @@ struct ChannelFront {
     name: Option<String>,
 }
 
+#[derive(serde::Deserialize)]
+struct ToolFront {
+    kind: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -244,6 +332,7 @@ mod tests {
         std::fs::create_dir_all(base.join("skills")).unwrap();
         std::fs::create_dir_all(base.join("schedules")).unwrap();
         std::fs::create_dir_all(base.join("channels")).unwrap();
+        std::fs::create_dir_all(base.join("tools")).unwrap();
         std::fs::write(
             base.join("instructions.md"),
             "You are a release-notes agent. Be terse and accurate.",
@@ -262,6 +351,11 @@ mod tests {
         std::fs::write(
             base.join("channels/web.md"),
             "---\nkind: http\nport: 8787\n---\nInbound HTTP channel.\n",
+        )
+        .unwrap();
+        std::fs::write(
+            base.join("tools/github.md"),
+            "---\nkind: mcp\nname: github\ntransport: stdio\ncommand: echo\nargs: [\"hi\"]\n---\nGitHub MCP tools.\n",
         )
         .unwrap();
         base
@@ -297,7 +391,38 @@ mod tests {
         assert_eq!(agent.channels.len(), 1);
         assert_eq!(agent.channels[0].kind, "http");
 
+        // tools/*.md (kind=mcp) → parsed MCP server spec.
+        assert_eq!(agent.tools.len(), 1);
+        assert_eq!(agent.tools[0].kind(), "mcp");
+        assert_eq!(agent.tools[0].name(), "github");
+
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn unknown_tool_kind_is_an_error() {
+        let base =
+            std::env::temp_dir().join(format!("a3s-agentdir-toolkind-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(base.join("tools")).unwrap();
+        std::fs::write(base.join("instructions.md"), "role").unwrap();
+        std::fs::write(base.join("tools/x.md"), "---\nkind: wat\nname: x\n---\n").unwrap();
+        assert!(AgentDir::load(&base).is_err());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn duplicate_tool_name_is_an_error() {
+        let base =
+            std::env::temp_dir().join(format!("a3s-agentdir-tooldup-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(base.join("tools")).unwrap();
+        std::fs::write(base.join("instructions.md"), "role").unwrap();
+        let spec = "---\nkind: mcp\nname: dup\ntransport: stdio\ncommand: echo\n---\n";
+        std::fs::write(base.join("tools/a.md"), spec).unwrap();
+        std::fs::write(base.join("tools/b.md"), spec).unwrap();
+        assert!(AgentDir::load(&base).is_err());
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[test]

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -10,12 +10,14 @@
 //! Existing `.acl` config filenames are still accepted for compatibility.
 //! JSON support has been removed.
 
+pub mod agent_dir;
 mod loader;
 mod provider;
 mod search;
 #[cfg(test)]
 mod tests;
 
+pub use agent_dir::{AgentDir, ChannelSpec, ScheduleSpec};
 pub use provider::{ModelConfig, ModelCost, ModelLimit, ModelModalities, ProviderConfig};
 pub use search::{
     BrowserBackend, DocumentCacheConfig, DocumentOcrConfig, DocumentParserConfig, HeadlessConfig,

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -17,7 +17,7 @@ mod search;
 #[cfg(test)]
 mod tests;
 
-pub use agent_dir::{AgentDir, ChannelSpec, ScheduleSpec};
+pub use agent_dir::{AgentDir, ChannelSpec, ScheduleSpec, ToolSpec};
 pub use provider::{ModelConfig, ModelCost, ModelLimit, ModelModalities, ProviderConfig};
 pub use search::{
     BrowserBackend, DocumentCacheConfig, DocumentOcrConfig, DocumentParserConfig, HeadlessConfig,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -107,6 +107,8 @@ pub mod run;
 pub(crate) mod safety_gate;
 pub mod sandbox;
 pub mod security;
+#[cfg(feature = "serve")]
+pub mod serve;
 pub(crate) mod session_lane_queue;
 pub mod skills;
 pub mod store;

--- a/core/src/serve/daemon.rs
+++ b/core/src/serve/daemon.rs
@@ -70,6 +70,10 @@ pub async fn serve_agent_dir(
             opts.session_id = Some(format!("schedule:{}", spec.name));
         }
         let session = agent.session(workspace.clone(), Some(opts))?;
+        // Install the agent dir's tools/ (e.g. MCP servers) into each schedule
+        // session, so a scheduled turn can call them. Connection is fallible and
+        // surfaces here (fail at startup, not at first call).
+        super::tools::install_agent_dir_tools(&session, &agent_dir.tools).await?;
         sessions.insert(spec.name.clone(), Arc::new(session));
     }
 
@@ -106,6 +110,7 @@ providers "anthropic" {
             },
             schedules,
             channels: vec![],
+            tools: vec![],
         }
     }
 

--- a/core/src/serve/daemon.rs
+++ b/core/src/serve/daemon.rs
@@ -1,0 +1,141 @@
+//! The serve daemon: runs a filesystem-first agent's cron schedules as full,
+//! durable harness turns until cancelled.
+//!
+//! Each schedule fires on its OWN session (stable id `schedule:<name>`), so a
+//! schedule's repeated fires accumulate context/memory while distinct schedules
+//! stay isolated. The agent dir's `instructions.md` (prompt slots) and `skills/`
+//! (`skill_dirs`) are injected into every schedule session via [`SessionOptions`].
+//!
+//! Channels and full multi-session rehydration attach here next; the design keeps
+//! every triggered run a FULL harness turn (`AgentSession::send`), never a raw
+//! model call.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+
+use super::schedule::{ScheduleSink, Scheduler};
+use crate::agent_api::{Agent, AgentSession, SessionOptions};
+use crate::config::{AgentDir, ScheduleSpec};
+use crate::error::Result;
+
+/// Routes each schedule fire to that schedule's own [`AgentSession`] as a `send`
+/// turn (context, tool visibility, safety gate, verification all stay on).
+struct SessionScheduleSink {
+    sessions: HashMap<String, Arc<AgentSession>>,
+}
+
+#[async_trait::async_trait]
+impl ScheduleSink for SessionScheduleSink {
+    async fn fire(&self, spec: &ScheduleSpec) {
+        let Some(session) = self.sessions.get(&spec.name) else {
+            tracing::warn!(schedule = %spec.name, "no session for schedule; skipping fire");
+            return;
+        };
+        match session.send(&spec.prompt, None).await {
+            Ok(_) => tracing::info!(schedule = %spec.name, "scheduled turn completed"),
+            Err(e) => {
+                tracing::warn!(schedule = %spec.name, error = %e, "scheduled turn failed")
+            }
+        }
+    }
+}
+
+/// Serve an agent directory's schedules until `cancel` fires.
+///
+/// Builds one session per enabled schedule (stable id `schedule:<name>`),
+/// injecting the agent dir's `prompt_slots` and `skill_dirs`. `extra` merges into
+/// every schedule session's [`SessionOptions`] (model, `llm_client`,
+/// `session_store`, …) — `prompt_slots`/`session_id` set there are NOT overridden,
+/// so a host can pin them per schedule if it wants.
+pub async fn serve_agent_dir(
+    agent: &Agent,
+    agent_dir: &AgentDir,
+    workspace: impl Into<String> + Clone,
+    extra: Option<SessionOptions>,
+    cancel: CancellationToken,
+) -> Result<()> {
+    let extra = extra.unwrap_or_default();
+    let mut sessions = HashMap::new();
+
+    for spec in agent_dir.schedules.iter().filter(|s| s.enabled) {
+        let mut opts = extra.clone();
+        if opts.prompt_slots.is_none() {
+            opts.prompt_slots = Some(agent_dir.prompt_slots.clone());
+        }
+        opts.skill_dirs
+            .extend(agent_dir.config.skill_dirs.iter().cloned());
+        if opts.session_id.is_none() {
+            opts.session_id = Some(format!("schedule:{}", spec.name));
+        }
+        let session = agent.session(workspace.clone(), Some(opts))?;
+        sessions.insert(spec.name.clone(), Arc::new(session));
+    }
+
+    let scheduler = Scheduler::new(agent_dir.schedules.clone())?;
+    let sink: Arc<dyn ScheduleSink> = Arc::new(SessionScheduleSink { sessions });
+    scheduler.run(sink, cancel).await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CodeConfig;
+    use crate::prompts::SystemPromptSlots;
+
+    fn test_agent_config() -> CodeConfig {
+        let acl = r#"
+default_model = "anthropic/claude-sonnet-4-20250514"
+providers "anthropic" {
+  api_key = "test-key"
+  models "claude-sonnet-4-20250514" { name = "Claude Sonnet 4" }
+}
+"#;
+        CodeConfig::from_acl(acl).unwrap()
+    }
+
+    fn agent_dir_with(schedules: Vec<ScheduleSpec>) -> AgentDir {
+        AgentDir {
+            dir: std::path::PathBuf::from("/tmp/serve-test-agent"),
+            config: CodeConfig::default(),
+            prompt_slots: SystemPromptSlots {
+                role: Some("a scheduled test agent".to_string()),
+                ..Default::default()
+            },
+            schedules,
+            channels: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn serve_with_no_schedules_returns_immediately() {
+        let agent = Agent::from_config(test_agent_config()).await.unwrap();
+        let dir = agent_dir_with(vec![]);
+        let cancel = CancellationToken::new();
+        // No schedules → no sessions, no jobs; returns Ok without blocking.
+        serve_agent_dir(&agent, &dir, "/tmp/ws".to_string(), None, cancel)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn serve_builds_per_schedule_session_and_stops_on_cancel() {
+        let agent = Agent::from_config(test_agent_config()).await.unwrap();
+        let dir = agent_dir_with(vec![ScheduleSpec {
+            name: "tick".to_string(),
+            cron: "* * * * *".to_string(),
+            prompt: "do the scheduled work".to_string(),
+            enabled: true,
+        }]);
+        // Pre-cancel: the per-schedule session is created and the scheduler starts,
+        // but the job loop returns on the cancelled token before any fire — so this
+        // exercises session creation + wiring + graceful shutdown with no LLM call.
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        serve_agent_dir(&agent, &dir, "/tmp/ws".to_string(), None, cancel)
+            .await
+            .unwrap();
+    }
+}

--- a/core/src/serve/mod.rs
+++ b/core/src/serve/mod.rs
@@ -10,6 +10,8 @@
 //! (context, tool visibility, safety gate, verification) via `AgentSession::send`,
 //! never a raw model call.
 
+pub mod daemon;
 pub mod schedule;
 
+pub use daemon::serve_agent_dir;
 pub use schedule::{ScheduleSink, ScheduledJob, Scheduler};

--- a/core/src/serve/mod.rs
+++ b/core/src/serve/mod.rs
@@ -12,6 +12,8 @@
 
 pub mod daemon;
 pub mod schedule;
+pub mod tools;
 
 pub use daemon::serve_agent_dir;
 pub use schedule::{ScheduleSink, ScheduledJob, Scheduler};
+pub use tools::install_agent_dir_tools;

--- a/core/src/serve/mod.rs
+++ b/core/src/serve/mod.rs
@@ -1,0 +1,15 @@
+//! Durable serve layer for filesystem-first agents.
+//!
+//! Builds strictly on top of a3s-code's existing primitives — no new execution
+//! machinery. Today it provides cron [`schedule`]s; the serve daemon (a session
+//! registry persisted via `SessionStore`, graceful shutdown, rehydrate-on-boot)
+//! and inbound channels attach here next. Gated behind the `serve` feature so
+//! library-only embedders pay nothing.
+//!
+//! Invariant: every schedule/channel-triggered run is a FULL harness turn
+//! (context, tool visibility, safety gate, verification) via `AgentSession::send`,
+//! never a raw model call.
+
+pub mod schedule;
+
+pub use schedule::{ScheduleSink, ScheduledJob, Scheduler};

--- a/core/src/serve/schedule.rs
+++ b/core/src/serve/schedule.rs
@@ -1,0 +1,190 @@
+//! Cron-driven schedules for filesystem-first agents (P1).
+//!
+//! A `schedules/<name>.md` file (parsed into a [`ScheduleSpec`] by the agent-dir
+//! convention) fires a markdown prompt into the agent on a cron cadence. The
+//! firing itself goes through a [`ScheduleSink`] — the serve daemon implements it
+//! to route the prompt through `AgentSession::send`, so a scheduled turn is a
+//! FULL harness turn (context, safety gate, verification), never a raw model call.
+
+use std::str::FromStr;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use cron::Schedule;
+use tokio_util::sync::CancellationToken;
+
+use crate::config::ScheduleSpec;
+use crate::error::{CodeError, Result};
+
+/// A parsed, fireable schedule: a [`ScheduleSpec`] with its compiled cron.
+pub struct ScheduledJob {
+    pub spec: ScheduleSpec,
+    schedule: Schedule,
+}
+
+impl ScheduledJob {
+    /// Parse a spec's cron. Accepts standard 5-field cron
+    /// (`min hour dom mon dow`) and the 6-field form (`sec min hour dom mon dow`).
+    pub fn parse(spec: ScheduleSpec) -> Result<Self> {
+        let schedule = Schedule::from_str(&normalize_cron(&spec.cron)).map_err(|e| {
+            CodeError::Context(format!(
+                "schedule '{}' has an invalid cron '{}': {e}",
+                spec.name, spec.cron
+            ))
+        })?;
+        Ok(Self { spec, schedule })
+    }
+
+    /// The next fire time strictly after `now` (None if it never fires again).
+    pub fn next_fire_after(&self, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+        self.schedule.after(&now).next()
+    }
+}
+
+/// Normalize a cron expression to the 6-field form the `cron` crate expects:
+/// standard 5-field cron gets a leading `0` seconds field.
+fn normalize_cron(expr: &str) -> String {
+    let expr = expr.trim();
+    match expr.split_whitespace().count() {
+        5 => format!("0 {expr}"),
+        _ => expr.to_string(),
+    }
+}
+
+/// What to do when a schedule fires. The serve daemon implements this to drive
+/// the schedule's markdown prompt into `AgentSession::send` (a full harness turn).
+#[async_trait::async_trait]
+pub trait ScheduleSink: Send + Sync {
+    async fn fire(&self, spec: &ScheduleSpec);
+}
+
+/// Drives a set of cron schedules: for each enabled job, sleep until its next
+/// fire, invoke the sink, repeat — until cancelled.
+pub struct Scheduler {
+    jobs: Vec<ScheduledJob>,
+}
+
+impl Scheduler {
+    /// Build from specs, skipping disabled ones. Errors on any invalid cron.
+    pub fn new(specs: impl IntoIterator<Item = ScheduleSpec>) -> Result<Self> {
+        let jobs = specs
+            .into_iter()
+            .filter(|s| s.enabled)
+            .map(ScheduledJob::parse)
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self { jobs })
+    }
+
+    /// Number of active (enabled, valid) jobs.
+    pub fn job_count(&self) -> usize {
+        self.jobs.len()
+    }
+
+    /// Run until `cancel` fires; one independent loop per job.
+    pub async fn run(self, sink: Arc<dyn ScheduleSink>, cancel: CancellationToken) {
+        let mut handles = Vec::new();
+        for job in self.jobs {
+            let sink = Arc::clone(&sink);
+            let cancel = cancel.clone();
+            handles.push(tokio::spawn(run_job(job, sink, cancel)));
+        }
+        for h in handles {
+            let _ = h.await;
+        }
+    }
+}
+
+async fn run_job(job: ScheduledJob, sink: Arc<dyn ScheduleSink>, cancel: CancellationToken) {
+    loop {
+        let now = Utc::now();
+        let Some(next) = job.next_fire_after(now) else {
+            return; // never fires again
+        };
+        let wait = (next - now)
+            .to_std()
+            .unwrap_or(std::time::Duration::from_secs(0));
+        tokio::select! {
+            _ = tokio::time::sleep(wait) => sink.fire(&job.spec).await,
+            _ = cancel.cancelled() => return,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn spec(name: &str, cron: &str, enabled: bool) -> ScheduleSpec {
+        ScheduleSpec {
+            name: name.to_string(),
+            cron: cron.to_string(),
+            prompt: "do the thing".to_string(),
+            enabled,
+        }
+    }
+
+    #[test]
+    fn parses_5_field_cron_and_computes_next_fire() {
+        let job = ScheduledJob::parse(spec("daily", "0 9 * * *", true)).unwrap();
+        // Before 09:00 → fires at 09:00 the same day.
+        let before = DateTime::parse_from_rfc3339("2026-01-01T08:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(
+            job.next_fire_after(before).unwrap().to_rfc3339(),
+            "2026-01-01T09:00:00+00:00"
+        );
+        // After 09:00 → next is 09:00 the following day.
+        let after = DateTime::parse_from_rfc3339("2026-01-01T10:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(
+            job.next_fire_after(after).unwrap().to_rfc3339(),
+            "2026-01-02T09:00:00+00:00"
+        );
+    }
+
+    #[test]
+    fn invalid_cron_is_an_error() {
+        assert!(ScheduledJob::parse(spec("bad", "not a cron", true)).is_err());
+    }
+
+    #[test]
+    fn scheduler_skips_disabled_and_rejects_bad_cron() {
+        let s = Scheduler::new([
+            spec("a", "0 9 * * *", true),
+            spec("b", "*/5 * * * *", false), // disabled → skipped
+        ])
+        .unwrap();
+        assert_eq!(s.job_count(), 1);
+
+        assert!(Scheduler::new([spec("bad", "xyz", true)]).is_err());
+    }
+
+    #[tokio::test]
+    async fn fires_at_least_once_then_stops_on_cancel() {
+        struct CountSink(Arc<AtomicUsize>);
+        #[async_trait::async_trait]
+        impl ScheduleSink for CountSink {
+            async fn fire(&self, _spec: &ScheduleSpec) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        let fires = Arc::new(AtomicUsize::new(0));
+        // 6-field cron = every second; a short real wait yields >= 1 fire without
+        // paused-clock plumbing (run_job mixes wall-clock next-fire with the timer).
+        let s = Scheduler::new([spec("sec", "* * * * * *", true)]).unwrap();
+        let cancel = CancellationToken::new();
+        let sink = Arc::new(CountSink(Arc::clone(&fires)));
+        let handle = tokio::spawn(s.run(sink, cancel.clone()));
+        tokio::time::sleep(std::time::Duration::from_millis(2200)).await;
+        cancel.cancel();
+        let _ = handle.await;
+        assert!(
+            fires.load(Ordering::SeqCst) >= 1,
+            "expected at least one fire in ~2.2s, got {}",
+            fires.load(Ordering::SeqCst)
+        );
+    }
+}

--- a/core/src/serve/tools.rs
+++ b/core/src/serve/tools.rs
@@ -1,0 +1,56 @@
+//! Install an agent directory's `tools/` specs into a live session.
+//!
+//! Parsing happens in [`AgentDir::load`](crate::config::AgentDir) (always, like
+//! `schedules`/`channels`); *installation* is a session-time operation here so it
+//! reuses the same fallible, harness-owned registration the SDK's
+//! [`add_mcp_server`](crate::AgentSession::add_mcp_server) already exposes — tool
+//! definition comes from the directory, but visibility and the safety gate stay
+//! with the harness.
+
+use crate::agent_api::AgentSession;
+use crate::config::ToolSpec;
+use crate::error::Result;
+
+/// Install each parsed [`ToolSpec`] into `session`.
+///
+/// `mcp` specs are registered and connected via the existing `add_mcp_server`
+/// path, so their tools land as `mcp__<server>__<tool>` and are gated by the
+/// session's permission policy like any other tool. Connection is fallible and
+/// surfaces here (e.g. a missing `command` binary), so a misconfigured tool fails
+/// at serve startup rather than silently at first call.
+pub async fn install_agent_dir_tools(session: &AgentSession, specs: &[ToolSpec]) -> Result<()> {
+    for spec in specs {
+        match spec {
+            ToolSpec::Mcp(config) => {
+                session.add_mcp_server(config.clone()).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_api::Agent;
+    use crate::config::CodeConfig;
+
+    fn test_config() -> CodeConfig {
+        let acl = r#"
+default_model = "anthropic/claude-sonnet-4-20250514"
+providers "anthropic" {
+  api_key = "test-key"
+  models "claude-sonnet-4-20250514" { name = "Claude Sonnet 4" }
+}
+"#;
+        CodeConfig::from_acl(acl).unwrap()
+    }
+
+    #[tokio::test]
+    async fn install_with_no_tools_is_ok() {
+        let agent = Agent::from_config(test_config()).await.unwrap();
+        let session = agent.session("/tmp/ws", None).unwrap();
+        // Empty specs → no MCP connect attempted, returns Ok without a live server.
+        install_agent_dir_tools(&session, &[]).await.unwrap();
+    }
+}

--- a/core/tests/test_agent_dir_tools.rs
+++ b/core/tests/test_agent_dir_tools.rs
@@ -1,0 +1,83 @@
+//! Integration tests for the agent-dir `tools/` install path.
+//!
+//! Hermetic (no LLM, no network): exercises the real
+//! `AgentDir::load -> install_agent_dir_tools -> add_mcp_server -> connect` chain
+//! against a bogus MCP command, asserting it fails CLOSED at install rather than
+//! silently at first call. Requires the `serve` feature:
+//!
+//! ```bash
+//! cargo test -p a3s-code-core --features serve --test test_agent_dir_tools
+//! ```
+#![cfg(feature = "serve")]
+
+use a3s_code_core::config::{AgentDir, CodeConfig};
+use a3s_code_core::serve::install_agent_dir_tools;
+use a3s_code_core::Agent;
+
+/// A provider config with a placeholder key. No LLM call is made by these tests
+/// (only the local MCP-connect path runs), so the key is never used.
+fn fake_config() -> CodeConfig {
+    CodeConfig::from_acl(
+        r#"
+default_model = "anthropic/claude-sonnet-4-20250514"
+providers "anthropic" {
+  api_key = "test-key"
+  models "claude-sonnet-4-20250514" { name = "Claude Sonnet 4" }
+}
+"#,
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn tools_mcp_parsed_and_install_fails_closed_on_bad_command() {
+    // An agent dir whose tools/ declares an MCP server pointing at a command that
+    // does not exist.
+    let dir = tempfile::tempdir().expect("agent dir");
+    std::fs::write(dir.path().join("instructions.md"), "role").unwrap();
+    std::fs::create_dir_all(dir.path().join("tools")).unwrap();
+    std::fs::write(
+        dir.path().join("tools/bad.md"),
+        "---\nkind: mcp\nname: bad\ntransport: stdio\ncommand: a3s-nonexistent-binary-zzz\n---\nbogus server\n",
+    )
+    .unwrap();
+
+    // Parse: the convention loader turns tools/bad.md into one ToolSpec::Mcp.
+    let agent_dir = AgentDir::load(dir.path()).expect("load agent dir");
+    assert_eq!(agent_dir.tools.len(), 1, "tools/ should parse one spec");
+    assert_eq!(agent_dir.tools[0].kind(), "mcp");
+    assert_eq!(agent_dir.tools[0].name(), "bad");
+
+    // Install into a real session: the MCP command can't be spawned, so connect
+    // fails and the error propagates (fail-closed at startup).
+    let agent = Agent::from_config(fake_config()).await.expect("agent");
+    let workspace = tempfile::tempdir().expect("workspace");
+    let session = agent
+        .session(workspace.path().to_string_lossy().to_string(), None)
+        .expect("session");
+
+    let result = install_agent_dir_tools(&session, &agent_dir.tools).await;
+    assert!(
+        result.is_err(),
+        "install must fail closed when the MCP server command cannot be spawned"
+    );
+}
+
+#[tokio::test]
+async fn install_with_empty_tools_is_ok() {
+    // No tools/ → nothing to install → Ok, no connection attempted.
+    let dir = tempfile::tempdir().expect("agent dir");
+    std::fs::write(dir.path().join("instructions.md"), "role").unwrap();
+    let agent_dir = AgentDir::load(dir.path()).expect("load");
+    assert!(agent_dir.tools.is_empty());
+
+    let agent = Agent::from_config(fake_config()).await.expect("agent");
+    let workspace = tempfile::tempdir().expect("workspace");
+    let session = agent
+        .session(workspace.path().to_string_lossy().to_string(), None)
+        .expect("session");
+
+    install_agent_dir_tools(&session, &agent_dir.tools)
+        .await
+        .expect("empty install is Ok");
+}

--- a/core/tests/test_serve_agent_dir_real_llm.rs
+++ b/core/tests/test_serve_agent_dir_real_llm.rs
@@ -1,0 +1,145 @@
+//! Real-LLM integration tests for the serve layer (filesystem-first agents).
+//!
+//! `#[ignore]` — requires a live provider in `.a3s/config.acl`. Run:
+//!
+//! ```bash
+//! cargo test -p a3s-code-core --features serve \
+//!   --test test_serve_agent_dir_real_llm -- --ignored --nocapture
+//! ```
+//!
+//! These exercise the cross-module path the in-crate unit tests stub out: a cron
+//! schedule firing a FULL harness turn through a real `AgentSession::send`.
+#![cfg(feature = "serve")]
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+
+use a3s_code_core::config::{AgentDir, CodeConfig, ScheduleSpec};
+use a3s_code_core::serve::{serve_agent_dir, ScheduleSink, Scheduler};
+use a3s_code_core::{Agent, AgentSession};
+
+/// Same resolution as the other `*_real_llm` tests: `A3S_CONFIG_FILE` or the repo
+/// root `.a3s/config.acl`.
+fn repo_config_path() -> PathBuf {
+    std::env::var_os("A3S_CONFIG_FILE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../../..")
+                .join(".a3s/config.acl")
+        })
+}
+
+async fn real_agent() -> Agent {
+    let path = repo_config_path();
+    let config = CodeConfig::from_file(&path)
+        .unwrap_or_else(|e| panic!("failed to load {}: {e}", path.display()));
+    Agent::from_config(config)
+        .await
+        .expect("build agent from real config")
+}
+
+/// Drives a schedule's prompt through a real `AgentSession::send` (the same path
+/// the serve daemon's internal sink uses) and records each completed turn's text.
+struct RecordingSink {
+    session: Arc<AgentSession>,
+    fires: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait::async_trait]
+impl ScheduleSink for RecordingSink {
+    async fn fire(&self, spec: &ScheduleSpec) {
+        match self.session.send(&spec.prompt, None).await {
+            Ok(result) => self.fires.lock().unwrap().push(result.text),
+            Err(e) => panic!("scheduled real turn failed: {e}"),
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires a live provider in .a3s/config.acl"]
+async fn schedule_fires_a_real_harness_turn() {
+    let agent = real_agent().await;
+    let workspace = tempfile::tempdir().expect("temp workspace");
+    let session = Arc::new(
+        agent
+            .session(workspace.path().to_string_lossy().to_string(), None)
+            .expect("session"),
+    );
+    let fires = Arc::new(Mutex::new(Vec::new()));
+    let sink = Arc::new(RecordingSink {
+        session,
+        fires: Arc::clone(&fires),
+    });
+
+    // Every-second cron → at least one fire within the window. Each fire is a FULL
+    // harness turn (real LLM), exactly as serve_agent_dir does internally.
+    let scheduler = Scheduler::new([ScheduleSpec {
+        name: "tick".to_string(),
+        cron: "* * * * * *".to_string(),
+        prompt: "Reply with exactly one word: PONG".to_string(),
+        enabled: true,
+    }])
+    .expect("scheduler");
+
+    let cancel = CancellationToken::new();
+    let handle = tokio::spawn(scheduler.run(sink, cancel.clone()));
+    tokio::time::sleep(Duration::from_secs(12)).await;
+    cancel.cancel();
+    let _ = handle.await;
+
+    let recorded = fires.lock().unwrap();
+    assert!(
+        !recorded.is_empty(),
+        "the schedule should have fired at least one real harness turn"
+    );
+    assert!(
+        recorded.iter().any(|t| !t.trim().is_empty()),
+        "a real LLM turn should return non-empty text; got {recorded:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires a live provider in .a3s/config.acl"]
+async fn serve_agent_dir_runs_a_real_schedule_and_stops() {
+    let agent = real_agent().await;
+
+    // A minimal agent dir: instructions + one every-second schedule.
+    let dir = tempfile::tempdir().expect("agent dir");
+    std::fs::write(
+        dir.path().join("instructions.md"),
+        "You are a terse test agent. Answer in one word.",
+    )
+    .unwrap();
+    std::fs::create_dir_all(dir.path().join("schedules")).unwrap();
+    std::fs::write(
+        dir.path().join("schedules/tick.md"),
+        "---\ncron: \"* * * * * *\"\nname: tick\n---\nReply with exactly one word: PONG",
+    )
+    .unwrap();
+    let agent_dir = AgentDir::load(dir.path()).expect("load agent dir");
+
+    let workspace = tempfile::tempdir().expect("workspace");
+    let cancel = CancellationToken::new();
+    {
+        let cancel = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(8)).await;
+            cancel.cancel();
+        });
+    }
+
+    // Runs until cancelled; a real schedule fire happens inside, then a clean stop.
+    serve_agent_dir(
+        &agent,
+        &agent_dir,
+        workspace.path().to_string_lossy().to_string(),
+        None,
+        cancel,
+    )
+    .await
+    .expect("serve_agent_dir should run a real fire and stop cleanly");
+}

--- a/manual/AGENT_DIR_TOOLS_DESIGN.md
+++ b/manual/AGENT_DIR_TOOLS_DESIGN.md
@@ -1,0 +1,345 @@
+# Agent-Dir `tools/` Mapping — Design Doc
+
+Status: DESIGN ONLY (no implementation). Scope: how the optional `tools/`
+subdirectory of an eve-style agent directory becomes *executable* tools in
+A3S Code without ever running arbitrary host JavaScript or arbitrary host
+processes.
+
+> Harness guardrail (non-negotiable). A file dropped into `tools/` may become
+> **either** an MCP server connection **or** a sandboxed QuickJS program. It is
+> NEVER turned into a free-running host JS/native process, and it NEVER gets to
+> define its own tool-visibility or safety policy. Tool *definition* is allowed
+> from the directory; tool *visibility* and *safety* remain harness-owned. This
+> is the deliberate divergence from eve's user-defined-tools model already
+> documented in `core/src/config/agent_dir.rs` (the module header) and is the
+> reason `tools/` is currently only a reserved placeholder (`agent_dir.rs:15`).
+
+---
+
+## 1. Where this fits today
+
+The agent-dir convention is loaded by `AgentDir::load(dir)` in
+`core/src/config/agent_dir.rs:75`. It synthesizes existing config objects from a
+directory by convention:
+
+```text
+agent/
+├── instructions.md   (required)  → SystemPromptSlots.role
+├── agent.acl          (optional)  → CodeConfig
+├── skills/            (optional)  → CodeConfig.skill_dirs
+├── schedules/         (optional)  → Vec<ScheduleSpec>   (serve layer)
+├── channels/          (optional)  → Vec<ChannelSpec>    (design-only)
+└── tools/             (optional)  → reserved (THIS DOC)
+```
+
+`tools/` is parsed by NOTHING today — line 15 of `agent_dir.rs` is a comment
+only, and `AgentDir::load` does not walk the subdirectory. Two runtime seams
+already exist that this design reuses verbatim; we are wiring, not inventing:
+
+1. MCP registration — `AgentSession::add_mcp_server(McpServerConfig)`
+   (`core/src/agent_api.rs:1305`) → `SessionExtensionRuntime::add_mcp_server`
+   (`core/src/agent_api/session_extensions.rs:62`), which registers, connects,
+   fetches `list_tools()`, wraps with `create_mcp_tools()`
+   (`core/src/mcp/tools.rs:83`, prefix `mcp__<server>__<tool>`), and calls
+   `tool_executor.register_dynamic_tool(...)`.
+2. Sandboxed JS — the `program` tool runs user JS in an embedded QuickJS VM via
+   `run_quickjs_script` (`core/src/tools/program_tool.rs:258`). It already loads
+   a workspace-relative `.js`/`.mjs` by `path` (`load_script_source`,
+   `program_tool.rs:177`), parse-time-blocks `import/eval/Function/Worker/
+   WebSocket/fetch` (`validate_script_source`, `program_tool.rs:230`), and runs
+   under memory/stack/timeout/tool-call/output limits with a frozen `ctx`
+   (`embedded_script_bootstrap`, `program_tool.rs:406`).
+
+The whole job of `tools/` is to declare, by file, *which* of these two existing
+backends to instantiate and with what bounded parameters.
+
+---
+
+## 2. (a) `tools/` file conventions
+
+### 2.1 One manifest file per tool, declarative, no executable manifest
+
+Each entry is a single declarative file. We do NOT use a `.js` file as the
+manifest (a bare `.js` is ambiguous — is it the program source or a config?),
+and we do NOT execute the manifest. Two accepted forms, chosen to match the rest
+of the convention and the existing config loaders:
+
+- `tools/<name>.acl` — HCL/ACL (preferred per repo Code Style: "Prefer HCL over
+  TOML"). Parsed with the same path `CodeConfig::from_file` already uses for
+  `agent.acl`.
+- `tools/<name>.md` — YAML frontmatter + body, identical mechanics to
+  `schedules/*.md` and `channels/*.{md,acl}`. Reuses `split_frontmatter`
+  (`agent_dir.rs:202`) and `md_files` (`agent_dir.rs:126`). The body, when
+  present, is treated as the tool *description* surfaced to the model.
+
+A `kind:` discriminant selects the backend. This mirrors `ChannelFront.kind`
+exactly (`agent_dir.rs:230`), so there is one established pattern for "a spec
+file that names which adapter handles it."
+
+```text
+kind = "mcp"        → MCP server connection  (backend 1)
+kind = "script"     → sandboxed QuickJS PTC  (backend 2)
+```
+
+Unknown `kind` is a hard load error (fail closed). A program-source `.js`/`.mjs`
+referenced by a `kind = "script"` spec lives anywhere workspace-relative;
+the spec points at it, the spec is never the program.
+
+### 2.2 `kind = "mcp"` spec → `McpServerConfig`
+
+The spec is a 1:1 surface over the *already-deserializable*
+`McpServerConfig` (`core/src/mcp/protocol.rs:393`). That type already has a
+hand-written `Deserialize` accepting the flat ACL form
+(`transport = "stdio" | "http" | "streamable-http"`, plus `command`/`args` or
+`url`/`headers`), `env`, `oauth`, and `tool_timeout_secs`. So the loader does
+*no new parsing*: it deserializes the file body into `McpServerConfig`.
+
+```hcl
+# tools/github.acl
+kind        = "mcp"
+name        = "github"            # used for the mcp__github__* prefix
+transport   = "stdio"
+command     = "npx"
+args        = ["-y", "@modelcontextprotocol/server-github"]
+enabled     = true
+# secrets come from the process env, not the file (see Security)
+env = { GITHUB_TOKEN = "${env:GITHUB_TOKEN}" }
+tool_timeout_secs = 60
+```
+
+### 2.3 `kind = "script"` spec → bounded `program` invocation
+
+The spec names a workspace-relative `.js`/`.mjs` source and pins the sandbox
+limits + allow-list. The fields map directly onto the `program` tool's existing
+arguments (`program_tool.rs:47` parameters, `ScriptLimits` at `:112`).
+
+```markdown
+---
+kind: script
+name: search-auth
+path: scripts/ptc/search-auth.js   # must end .js/.mjs (program_tool.rs:188)
+allowed_tools: [grep, glob, read]  # subset; program is always excluded
+limits:
+  timeoutMs: 30000
+  maxToolCalls: 30
+  maxOutputBytes: 65536
+---
+Find auth-related files and return an evidence list.  (← model-facing description)
+```
+
+The source must define `async function run(ctx, inputs)` — enforced by
+`script_source_with_host_entrypoint` (`program_tool.rs:330`). The declared
+`name` becomes the *model-visible tool name* (see §4 for the thin wrapper).
+
+### 2.4 Loader output (parse, don't wire, in `AgentDir::load`)
+
+Following the `schedules`/`channels` precedent, `AgentDir::load` only *parses*
+`tools/` into typed specs and stores them on `AgentDir`. Actual registration is
+done at session build time (§3), exactly as `add_mcp_server` is a session-level
+operation today. Proposed shape (names illustrative, not prescriptive):
+
+```rust
+pub enum ToolSpec {
+    Mcp(McpServerConfig),                 // backend 1
+    Script(ScriptToolSpec),               // backend 2
+}
+pub struct ScriptToolSpec {
+    pub name: String,
+    pub description: String,              // .md body, or frontmatter `description`
+    pub path: PathBuf,                    // workspace-relative .js/.mjs
+    pub allowed_tools: Option<Vec<String>>,
+    pub limits: ScriptLimits,             // reuse program_tool::ScriptLimits
+}
+// AgentDir gains:  pub tools: Vec<ToolSpec>,
+```
+
+Parsing rules (fail closed, mirroring existing loaders):
+- No frontmatter / missing `kind` → error, like `schedules`/`channels`.
+- `kind = "mcp"` with a malformed `McpServerConfig` → propagate the serde error.
+- `kind = "script"` whose `path` does not end `.js`/`.mjs` → error at load (do
+  not defer to first call).
+- Duplicate tool `name` across files → error (names are the registry key).
+
+---
+
+## 3. (b) The two execution backends and when each applies
+
+Decision is purely by `kind`; there is no auto-detection and no fallthrough.
+
+| `kind` | Backend | Runtime | Use when |
+|--------|---------|---------|----------|
+| `mcp` | MCP server connection | child process (stdio) or remote HTTP, spoken over the MCP protocol; A3S only sends/receives JSON-RPC | the capability is an external, already-MCP-shaped integration (GitHub, Postgres, a remote tool service). The "process" is the MCP server itself, launched/owned by `StdioTransport`/`HttpSseTransport` — A3S never `exec`s arbitrary user code, it speaks a protocol. |
+| `script` | sandboxed QuickJS PTC | in-process `rquickjs` VM, no fs/net/proc/env | the capability is local glue over *existing* A3S tools (grep→read→summarize), expressed as JS. The script cannot touch the host; it can only call back through the frozen `ctx` allow-list. |
+
+Why these two and nothing else (Rule 1 / Rule 2): together they cover "reach an
+external system" (MCP, isolated by being a separate protocol-speaking process)
+and "compose our own tools in a loop" (QuickJS, isolated by the VM). Neither
+path can become "run this `.js`/binary on the host with ambient authority,"
+which is precisely the eve model we are refusing.
+
+### 3.1 `mcp` registration flow (reused verbatim)
+
+At session build, for each `ToolSpec::Mcp(cfg)` call
+`session.add_mcp_server(cfg)` (`agent_api.rs:1305`). That already:
+`register_server` → `connect` (creates transport, `McpClient::initialize`,
+`list_tools`) → `create_mcp_tools` (prefix `mcp__<name>__<tool>`) →
+`register_dynamic_tool`. Removal is `remove_mcp_server` (unregister by
+`mcp__<name>__` prefix + disconnect). Idle servers can be reaped by the existing
+`McpManager::disconnect_idle`. No new MCP code is required.
+
+Invariant to preserve: the `mcp__<server>__<tool>` naming is baked into
+`McpToolWrapper::new` (`tools.rs:27`) and `McpManager::parse_tool_name`
+(`manager.rs:339`). A `tools/` MCP spec must not try to rename or unprefix —
+visibility/naming stays harness-owned.
+
+### 3.2 `script` registration flow (thin new wrapper, no new sandbox)
+
+The QuickJS executor already exists and is the only place JS runs. The single
+new piece is a thin `Tool` impl that, when called, invokes the same
+`program`-tool execution path with the spec's pinned `path` + `allowed_tools` +
+`limits` — i.e. it is a *named, pre-parameterized* `program` call. It adds NO new
+capability: it reuses `validate_script_source`, `run_quickjs_script`, the frozen
+`__a3sCtx`, the 64MB memory / 512KB stack / interrupt-timeout limits, and the
+per-call `maxToolCalls`/`maxOutputBytes` caps. See §4 for the seam.
+
+Why a wrapper instead of just telling the model "call `program` with this path":
+a named tool (`search-auth`) with its own description is what makes a `tools/`
+entry *discoverable* and selectable like any other tool, while the sandbox and
+allow-list stay fixed by the spec rather than chosen per-call by the model.
+
+---
+
+## 4. (c) How a `tools/`-sourced call still flows through visibility + safety
+
+Both backends terminate as ordinary `Arc<dyn Tool>` entries registered via
+`ToolExecutor::register_dynamic_tool` (`core/src/tools/mod.rs:390`). That single
+chokepoint is why "tool definition from the dir" cannot smuggle past
+"visibility + safety stays with the harness":
+
+1. Registration is mediated. `register_dynamic_tool` → `registry.register`
+   (`registry.rs:74`) refuses to shadow builtins. A `tools/` entry can never
+   replace `bash`, `read`, `program`, etc.
+2. Visibility is harness-derived. The model only ever sees what
+   `ToolRegistry::definitions()` (`registry.rs:119`) exposes — name +
+   description + JSON schema. A `tools/` tool is visible exactly like a built-in
+   or an MCP tool; it cannot inject itself into the prompt outside that surface,
+   and it cannot opt itself into being always-selected.
+3. Safety gate is unchanged and upstream of execution. Every model-driven tool
+   call is checked by the session's `PermissionChecker`
+   (`permissions/mod.rs:28`, Deny → Allow → Ask → HITL default) before the tool
+   runs. A `tools/` entry is just another `tool_name` fed to `check(...)`;
+   policy authored in `agent.acl`/host config still governs it. The directory
+   cannot grant itself `Allow`.
+4. Workspace boundary still applies. Execution goes through
+   `ToolExecutor::execute*` (`tools/mod.rs:453`/`:472`), which runs
+   `check_workspace_boundary` before dispatch.
+5. Backend-internal guards remain:
+   - `script`: the QuickJS VM has no fs/net/proc/env; the *only* outbound
+     capability is `ctx.tool(...)`, and `execute_host_tool_json`
+     (`program_tool.rs:436`) re-checks the per-script `allowed_tools` set and
+     the `maxToolCalls` counter on every hop. Crucially, those inner `ctx` calls
+     re-enter `registry.execute_with_context`, so a script calling `bash` is
+     still a `bash` execution subject to the same boundary checks.
+   - `mcp`: A3S never runs the server's code; it exchanges JSON-RPC. The server
+     is a separate process/endpoint owned by the transport layer.
+
+Net: a `tools/` file can *add a callable name*, but every actual invocation is
+double-gated (permission check + backend sandbox), and the name itself is
+non-shadowing and harness-namespaced (`mcp__…` for MCP). There is no path by
+which a directory file executes arbitrary host JS or an arbitrary host process.
+
+```text
+tools/<name>.{acl,md}
+   │  AgentDir::load  (parse only)
+   ▼
+ToolSpec ──┬─ Mcp(McpServerConfig)  ─► session.add_mcp_server ─► McpToolWrapper (mcp__name__*)
+           └─ Script(ScriptToolSpec) ─► AgentDirScriptTool      (name)
+                                          │
+                  register_dynamic_tool ◄─┘   (non-shadowing; builtins win)
+                                          │
+   model selects ──► PermissionChecker.check ──► ToolExecutor.execute ──► backend
+                       (Deny/Allow/Ask)          (workspace boundary)
+                                                   │
+                          MCP: JSON-RPC to server  │  script: QuickJS VM,
+                                                   │  frozen ctx, allow-list,
+                                                   ▼  limits — ctx.tool re-checks
+```
+
+---
+
+## 5. (d) Minimal trait/seam to add later
+
+Goal: the smallest possible new surface, reusing both existing backends. Two
+trait-free functions plus one tiny `Tool` impl. No new manager, no new sandbox,
+no new permission path (Rule 2: this is an *extension*, the core is untouched).
+
+### Seam 1 — parse (in `config/agent_dir.rs`, alongside `load_schedules`)
+
+```rust
+fn load_tools(dir: &Path) -> Result<Vec<ToolSpec>>;   // mirrors load_schedules/load_channels
+```
+Called from `AgentDir::load` after `channels`; stores `tools: Vec<ToolSpec>` on
+`AgentDir`. Pure parsing — fail closed, no I/O beyond reading the files.
+
+### Seam 2 — register (session build time, NOT inside `AgentDir::load`)
+
+A free function (or `SessionExtensionRuntime` method, next to `add_mcp_server`):
+```rust
+async fn install_agent_dir_tools(session: &AgentSession, specs: &[ToolSpec]) -> Result<()>;
+//   Mcp(cfg)    => session.add_mcp_server(cfg).await   (existing, unchanged)
+//   Script(spec)=> session.tool_executor
+//                         .register_dynamic_tool(Arc::new(AgentDirScriptTool::new(spec)))
+```
+Keeping registration at the session level preserves the existing rule that
+capability mutation is a session operation (the `add_mcp_server` precedent) and
+keeps `AgentDir::load` a pure, side-effect-free config synthesizer.
+
+### Seam 3 — the only new `Tool` impl
+
+`AgentDirScriptTool` is a named facade over the existing `program` execution. It
+holds the parsed `ScriptToolSpec` and, in `execute`, builds the same args the
+`program` tool already accepts (`{ type: "script", language: "javascript",
+path, allowed_tools, limits }`) and runs them through the existing
+`run_quickjs_script` path. It introduces no new sandbox primitive — it is a
+pre-parameterized, discoverable `program` call.
+
+```rust
+struct AgentDirScriptTool { spec: ScriptToolSpec }  // name()/description() from spec
+#[async_trait] impl Tool for AgentDirScriptTool {
+    // execute(): delegate to the existing program-script executor with
+    //            spec.path / spec.allowed_tools / spec.limits pinned.
+}
+```
+
+That is the entire footprint: one parser, one installer, one wrapper. MCP and
+QuickJS — and the permission + visibility chokepoints — are all reused as-is.
+
+---
+
+## 6. Non-goals / explicitly refused
+
+- No arbitrary host JS or native processes from `tools/` (the guardrail).
+- No per-tool permission policy authored in the `tools/` file — safety stays in
+  `agent.acl`/host `PermissionPolicy`. A directory file cannot self-`Allow`.
+- No renaming around the `mcp__<server>__<tool>` convention.
+- No new sandbox: `script` reuses the QuickJS VM and its existing limits.
+- `tools/` loading must not auto-connect MCP servers during pure config load —
+  connection is a session-time, fallible operation (the `add_mcp_server`
+  precedent), so a missing `npx`/network failure surfaces at session build, not
+  at directory parse.
+
+## 7. Open items for the implementing PR
+
+- Decide whether secrets in `kind="mcp"` specs use `${env:VAR}` interpolation or
+  rely on the host injecting `env` — keep secrets OUT of the file (Security in
+  `mcp.mdx`).
+- Confirm `ScriptLimits` is re-exportable from `tools::program_tool` for the
+  spec (currently private; either re-export or mirror the three numeric fields).
+- Tests (TDD, before code): load fixture `tools/` with one `mcp` + one `script`
+  spec; assert specs parse; assert duplicate-name and unknown-kind fail closed;
+  assert a registered `script` tool is non-shadowing and is gated by a Deny
+  permission rule.
+- Docs: a new `apps/docs/content/docs/en/code/agent-dir-tools.mdx` (YAML
+  frontmatter + body, using `mcp.mdx` as the format template) plus a `tools/`
+  section in `manual/USER_GUIDE.md`. Add to `meta.json`.
+

--- a/manual/CHANNELS_DESIGN.md
+++ b/manual/CHANNELS_DESIGN.md
@@ -1,0 +1,444 @@
+# Inbound Channels — Design Doc (eve parity)
+
+Status: DESIGN ONLY. No implementation. This document specifies the seam for
+turning external inbound messages (HTTP, Slack, Discord) into full harness turns
+on a filesystem-first agent directory. It is the channel companion to the cron
+`schedule` layer that already ships under the `serve` feature.
+
+Scope anchors (already in tree):
+
+- `core/src/config/agent_dir.rs` — parses `channels/*.{md,acl}` into
+  `ChannelSpec { name, kind, frontmatter }` and stores them on
+  `AgentDir { channels: Vec<ChannelSpec>, .. }`. This is done; this doc does NOT
+  change the parser.
+- `core/src/serve/schedule.rs` — `ScheduleSink` trait + `Scheduler` (cron loop).
+- `core/src/serve/daemon.rs` — `SessionScheduleSink` + `serve_agent_dir(..)`.
+- `core/src/serve/mod.rs` — `serve` feature module, re-exports.
+
+The channel layer MIRRORS the schedule layer. Where a schedule is a *time*
+source that fires a fixed prompt, a channel is a *message* source that fires an
+arriving message. Both converge on the SAME invariant and the SAME execution
+primitive (`AgentSession::send`).
+
+---
+
+## 0. The core invariant (read this first)
+
+> Every inbound channel message becomes a FULL harness turn via
+> `AgentSession::send`, never a raw model call.
+
+This is the entire reason the layer exists, and it is non-negotiable. An adapter
+NEVER touches `LlmClient`, never assembles a prompt string and calls a provider,
+never short-circuits tool/visibility/safety. The ONLY thing an adapter is
+allowed to do with an inbound message is:
+
+```rust
+let result: AgentResult = session.send(&message.text, None).await?;
+```
+
+`AgentSession::send(&self, prompt: &str, history: Option<&[Message]>) -> Result<AgentResult>`
+is what carries:
+
+- **Context**: the agent dir's `instructions.md` (injected as a prompt SLOT via
+  `SessionOptions::prompt_slots`, not a system-prompt override), the session's
+  accumulated history (`history = None` => use+update the session's own history),
+  and any `skill_dirs`/context providers configured on the session.
+- **Tool visibility**: tools are harness-owned. The adapter does not declare,
+  hide, or inject tools — this is the deliberate divergence from eve's
+  user-defined-tools model already documented in `agent_dir.rs`.
+- **Safety gate**: permission checker, security provider (taint/sanitization),
+  HITL confirmation, and budget guard all run inside `send`.
+- **Verification**: `AgentResult.verification_reports` is populated by the
+  harness's completion-evidence path; the adapter may surface it but never
+  replaces it.
+
+A reviewer can enforce the invariant with one grep: an adapter module that
+imports `crate::llm::LlmClient` (other than to *forward* a host-supplied one into
+`SessionOptions`) is wrong. The only execution call in any adapter is
+`session.send(..)`.
+
+Inbound text is UNTRUSTED. It enters as the `prompt` argument of a turn, which
+means the harness's existing prompt-injection / taint defenses (security
+provider, BOUNDARIES) are exactly the defenses that apply. Adapters add transport
+authentication on top (signature verification), they do not add or weaken
+model-layer safety.
+
+---
+
+## 1. The `ChannelAdapter` trait seam
+
+Lives in a new file `core/src/serve/channel.rs`, parallel to `schedule.rs`.
+
+Two responsibilities, split into two traits to keep transport concerns out of
+the session-routing core (single responsibility, mirrors how `ScheduleSink` is
+separate from `Scheduler`):
+
+### 1.1 `ChannelSink` — the harness-binding seam (core, stable)
+
+The exact analogue of `ScheduleSink`. The serve daemon implements it; it is the
+ONLY place a turn is fired. Adapters depend on this trait, never on
+`AgentSession` directly — so the "must go through `send`" rule is structurally
+enforced (an adapter literally has no other method to call).
+
+```rust
+/// An inbound message normalized from any transport. The adapter produces it;
+/// the sink turns it into a harness turn.
+#[derive(Debug, Clone)]
+pub struct InboundMessage {
+    /// Logical channel name (the `ChannelSpec.name`), e.g. "support-web".
+    pub channel: String,
+    /// Transport-stable conversation key used to derive the session id.
+    /// HTTP: caller-supplied conversation id (or a per-connection uuid).
+    /// Slack: channel_id + thread_ts. Discord: channel_id (+ thread id).
+    pub conversation: String,
+    /// The user's text — fired verbatim as the turn prompt.
+    pub text: String,
+    /// Opaque principal (Slack user id, Discord author id, HTTP auth subject).
+    /// Forwarded into SessionOptions.principal; never interpreted by core.
+    pub principal: Option<String>,
+}
+
+/// What to do when a channel message arrives. The serve daemon implements this
+/// to drive the message into `AgentSession::send` — a FULL harness turn
+/// (context, tool visibility, safety gate, verification), never a raw model call.
+#[async_trait::async_trait]
+pub trait ChannelSink: Send + Sync {
+    /// Fire one inbound message as a harness turn and return the reply.
+    /// Returns the reply so adapters can route it back (see §4).
+    async fn deliver(&self, msg: InboundMessage) -> crate::error::Result<ChannelReply>;
+}
+
+/// The harness's answer, shaped for routing back to the transport.
+#[derive(Debug, Clone)]
+pub struct ChannelReply {
+    /// AgentResult.text — the text to send back to the user.
+    pub text: String,
+    /// Echo of the conversation key, so the adapter knows where to route.
+    pub conversation: String,
+    /// True when verification is NeedsReview (adapter may flag the reply).
+    pub needs_review: bool,
+}
+```
+
+Note `deliver` RETURNS the reply rather than the sink pushing it. This keeps the
+sink transport-agnostic (it knows nothing about Slack `chat.postMessage` or HTTP
+response bodies) and lets each adapter route replies in its native idiom (§4).
+
+### 1.2 `ChannelAdapter` — the transport seam (extension, per-protocol)
+
+One impl per protocol. Owns the socket/listener, authenticates the transport,
+normalizes wire payloads into `InboundMessage`, calls `sink.deliver(..)`, and
+routes `ChannelReply` back. It runs until cancelled — exactly like a
+`Scheduler::run` job loop.
+
+```rust
+#[async_trait::async_trait]
+pub trait ChannelAdapter: Send + Sync {
+    /// Stable kind string matched against `ChannelSpec.kind` ("http"/"slack"/"discord").
+    fn kind(&self) -> &'static str;
+
+    /// Bind the transport and serve inbound messages until `cancel` fires.
+    /// Every accepted message is normalized and handed to `sink.deliver(..)`;
+    /// the returned `ChannelReply` is routed back over the transport.
+    async fn serve(
+        &self,
+        spec: &crate::config::ChannelSpec,
+        sink: std::sync::Arc<dyn ChannelSink>,
+        cancel: tokio_util::sync::CancellationToken,
+    ) -> crate::error::Result<()>;
+}
+```
+
+Adapter construction parses `ChannelSpec.frontmatter` (raw YAML) into a
+per-adapter typed options struct (`HttpOptions`, `SlackOptions`, `DiscordOptions`)
+with `serde`. The frontmatter is already captured by the parser; adapters own its
+interpretation, consistent with the `agent_dir.rs` doc comment ("`frontmatter`
+carries the raw adapter options for whichever adapter eventually handles `kind`").
+
+Why two traits and not one: `ChannelSink` is **core** (per Rule 2 — it is the
+harness-binding contract, non-replaceable). `ChannelAdapter` is an **extension** —
+each transport is replaceable/addable without touching the sink. A host could
+ship an SQS or WhatsApp adapter by implementing `ChannelAdapter` alone.
+
+---
+
+## 2. The three inbound adapters
+
+All three are feature-gated sub-modules under `core/src/serve/channels/` and
+share the §1 traits. Each is one file (one protocol per file). They differ ONLY
+in transport + auth + reply routing; the body of each handler is the same three
+steps: normalize -> `sink.deliver` -> route reply.
+
+### 2.1 HTTP (`channels/http.rs`, kind = `"http"`)
+
+- **Transport**: a small HTTP listener (server side via a gated `axum` dep — see
+  §6; `reqwest`/`tokio` are already deps). One `POST /message` endpoint.
+- **Frontmatter** (`HttpOptions`): `port: u16`, optional `path: String`
+  (default `/message`), optional `auth_token: String` (bearer) or
+  `auth_token_env: String`.
+- **Auth**: constant-time bearer-token compare; 401 on mismatch. No token =>
+  bind loopback only and log a warning (never expose an unauthenticated agent to
+  `0.0.0.0`).
+- **Request body**: `{ "conversation": "<id?>", "text": "..." }`. Missing
+  `conversation` => generate a per-request uuid (stateless one-shot turn).
+- **Reply routing**: synchronous — the `ChannelReply.text` is the HTTP 200 JSON
+  body `{ "text": "...", "needs_review": bool }`. This is the simplest adapter
+  and the reference impl for the trait.
+
+### 2.2 Slack (`channels/slack.rs`, kind = `"slack"`)
+
+- **Transport**: Slack Events API over HTTP (recommended for parity with eve and
+  to avoid a socket-mode websocket dependency). The adapter exposes one webhook
+  endpoint Slack POSTs events to.
+- **Frontmatter** (`SlackOptions`): `signing_secret_env`, `bot_token_env`,
+  optional `port`/`path`, optional `event_types` filter (default
+  `app_mention` + `message.im`).
+- **Auth**: verify the `X-Slack-Signature` HMAC-SHA256 over
+  `v0:{X-Slack-Request-Timestamp}:{body}` using the signing secret; reject stale
+  timestamps (replay guard). Respond to Slack's `url_verification` challenge.
+- **Normalize**: `conversation = format!("{channel_id}:{thread_ts_or_ts}")` so a
+  thread maps to one session; strip the bot mention from `text`; `principal =
+  event.user`. ACK Slack within 3s (return 200 immediately) and run `deliver` on
+  a spawned task — Slack retries on slow ACK, so the turn must not block the ACK.
+- **Reply routing**: asynchronous — post `ChannelReply.text` back via
+  `chat.postMessage` to the same channel/thread using the bot token. This is the
+  first adapter where reply routing is decoupled from the inbound request, which
+  is exactly why `deliver` returns the reply rather than writing a response body.
+
+### 2.3 Discord (`channels/discord.rs`, kind = `"discord"`)
+
+- **Transport**: Discord Gateway websocket (Discord has no inbound-webhook model
+  for receiving messages; a bot must hold a gateway connection). The adapter
+  maintains the gateway heartbeat and subscribes to `MESSAGE_CREATE`.
+- **Frontmatter** (`DiscordOptions`): `bot_token_env`, optional
+  `application_id`, optional `allowed_channels: Vec<String>`, intent flags.
+- **Auth**: the bot token authenticates the gateway connection itself; inbound
+  messages are trusted as gateway-delivered. Ignore messages authored by the bot
+  (loop guard) and messages outside `allowed_channels`.
+- **Normalize**: `conversation = channel_id` (or thread id when present);
+  `text = message.content`; `principal = author.id`.
+- **Reply routing**: asynchronous — `POST /channels/{id}/messages` with
+  `ChannelReply.text`.
+
+Adapter parity summary:
+
+| kind    | transport            | inbound auth         | reply routing            | session key |
+|---------|----------------------|----------------------|--------------------------|-------------|
+| http    | HTTP listener        | bearer token         | sync HTTP 200 body       | conversation id / per-req uuid |
+| slack   | Events API webhook   | HMAC signature       | async `chat.postMessage` | channel:thread_ts |
+| discord | Gateway websocket    | bot-token connection | async REST `messages`    | channel/thread id |
+
+---
+
+## 3. Session id mapping (one session per conversation)
+
+The schedule layer keys sessions by schedule name (`schedule:<name>`). Channels
+key sessions by **conversation**, because that is what should accumulate history.
+
+```text
+session_id = format!("channel:{}:{}", msg.channel, msg.conversation)
+```
+
+- `msg.channel` is the `ChannelSpec.name` — isolates two different channels that
+  happen to share a conversation id.
+- `msg.conversation` is the transport-stable thread key from §2.
+
+Properties this gives us, by mirroring the schedule design:
+
+- **Continuity**: repeated messages in the same thread reuse the same
+  `AgentSession`, so `send(text, None)` accumulates context across turns (the
+  harness owns history; the adapter passes `None`).
+- **Isolation**: distinct threads / channels get distinct sessions; no
+  cross-talk.
+- **Durability (later)**: because the id is stable and derived (not random), the
+  same `SessionStore`-backed rehydrate-on-boot path the daemon doc mentions for
+  schedules applies unchanged — a restarted daemon resumes a conversation's
+  session by recomputing its id.
+
+Session lifecycle: unlike schedules (fixed, known at boot), channel
+conversations are dynamic and unbounded. The `SessionChannelSink` therefore
+holds a `tokio::sync::Mutex<HashMap<String, Arc<AgentSession>>>` and lazily
+creates a session on first message for a conversation (get-or-create under the
+lock), reusing the agent dir's `prompt_slots` + `skill_dirs` exactly as
+`serve_agent_dir` does for schedules. A retention/idle policy (LRU cap, idle
+eviction via `session.close()`) is REQUIRED to avoid unbounded session growth —
+this is the one place channels need machinery schedules do not. Recommend a
+configurable `max_live_sessions` with LRU close; default conservative.
+
+---
+
+## 4. Reply routing
+
+The harness produces `AgentResult.text`. The sink wraps it as
+`ChannelReply { text, conversation, needs_review }` and returns it from
+`deliver`. The ADAPTER routes it, because only the adapter knows the transport:
+
+- **HTTP**: serialize the reply as the synchronous HTTP response body. The
+  caller's `conversation` is echoed so a stateless client can correlate.
+- **Slack/Discord**: the inbound request was already ACKed (Slack) or is a
+  fire-and-forget gateway event (Discord); the adapter routes the reply
+  out-of-band to `conversation` via the platform's send API, using credentials
+  from the adapter's frontmatter (`bot_token_env`).
+
+`needs_review` is derived from `AgentResult.verification_reports` (true when the
+summary status is `NeedsReview`). Adapters MAY use it (e.g. prefix the Slack
+reply with a warning, or set an HTTP header) but MUST NOT drop the reply — the
+harness already decided the turn completed; surfacing review state is a
+presentation concern.
+
+Errors: when `deliver` returns `Err` (closed session, send failure), HTTP
+returns 5xx; Slack/Discord log and post a terse "couldn't process that" to the
+conversation. The error is never the raw `CodeError` (don't leak internals to an
+untrusted channel).
+
+---
+
+## 5. Where adapters plug into `serve_agent_dir`
+
+Today `serve_agent_dir` builds per-schedule sessions, then runs one `Scheduler`.
+Channels attach in the SAME function as a second concurrent driver, joined under
+the same `cancel` token. Sketch (matches existing signatures —
+`Agent::session(workspace, Some(SessionOptions))`, `AgentSession::send`,
+`async_trait`):
+
+```rust
+// in core/src/serve/daemon.rs, inside serve_agent_dir(..), after the schedule wiring:
+
+// 1. One sink shared by every adapter; it owns lazy per-conversation sessions
+//    and is the ONLY caller of AgentSession::send for channels.
+let channel_sink: Arc<dyn ChannelSink> = Arc::new(SessionChannelSink::new(
+    agent,                           // to build sessions on demand (Agent::session takes &self)
+    agent_dir.clone(),               // prompt_slots + skill_dirs source
+    workspace.clone().into(),
+    extra.clone(),                   // merged SessionOptions, same rules as schedules
+));
+
+// 2. One adapter task per enabled channel, selected by kind.
+let mut adapter_handles = Vec::new();
+for spec in &agent_dir.channels {
+    let adapter: Arc<dyn ChannelAdapter> = match spec.kind.as_str() {
+        "http"    => Arc::new(HttpChannelAdapter::default()),
+        "slack"   => Arc::new(SlackChannelAdapter::default()),
+        "discord" => Arc::new(DiscordChannelAdapter::default()),
+        other => { tracing::warn!(kind = %other, "unknown channel kind; skipping"); continue; }
+    };
+    let (spec, sink, cancel) = (spec.clone(), Arc::clone(&channel_sink), cancel.clone());
+    adapter_handles.push(tokio::spawn(async move {
+        if let Err(e) = adapter.serve(&spec, sink, cancel).await {
+            tracing::warn!(channel = %spec.name, error = %e, "channel adapter stopped");
+        }
+    }));
+}
+
+// 3. Run schedules and channels concurrently; both stop on `cancel`.
+//    (Today the fn ends `scheduler.run(sink, cancel).await; Ok(())`. The new form
+//     joins the scheduler future with the adapter handles under the same token.)
+```
+
+Key points:
+
+- `SessionChannelSink` is the `ChannelSink` impl and lives in `daemon.rs` next to
+  `SessionScheduleSink`, for the same reason: it is the one place that holds
+  `AgentSession`s and fires `send`. The dispatch-by-`kind` match is the channel
+  analogue of `Scheduler::new(specs)`.
+- Per-channel `SessionOptions` follow the EXACT merge rules already in
+  `serve_agent_dir`: `prompt_slots` defaults to `agent_dir.prompt_slots` if the
+  host didn't pin one; `skill_dirs` extends with `agent_dir.config.skill_dirs`;
+  `session_id` is set by the sink per conversation (§3); `principal` is filled
+  from `InboundMessage.principal`.
+- No new execution machinery: the daemon stays a thin wiring layer over
+  `Agent`/`AgentSession`, consistent with `serve/mod.rs`'s "builds strictly on
+  top of existing primitives" promise.
+
+---
+
+## 6. Feature gating
+
+Channels stay under the existing `serve` feature, but transport deps are split so
+a host can take HTTP without dragging in Slack/Discord clients. Proposed
+`Cargo.toml` additions (mirrors the existing `serve = ["dep:cron"]` shape):
+
+```toml
+[features]
+# unchanged: cron schedules
+serve = ["dep:cron"]
+
+# Channel transports — each additive, each pulls only what it needs.
+serve-channels = ["serve"]                                  # the ChannelAdapter/ChannelSink seam
+serve-http     = ["serve-channels", "dep:axum"]             # HTTP inbound adapter
+serve-slack    = ["serve-channels", "dep:axum", "dep:hmac", "dep:sha2"]  # Events API + signature
+serve-discord  = ["serve-channels", "dep:tokio-tungstenite"]            # gateway websocket
+```
+
+- `core/src/serve/channel.rs` (the traits) is gated on `serve-channels`.
+- `core/src/serve/channels/http.rs` on `serve-http`, `slack.rs` on
+  `serve-slack`, `discord.rs` on `serve-discord`.
+- The dispatch `match` in `serve_agent_dir` `#[cfg(..)]`s each arm so an
+  unbuilt transport is a clean "unknown kind; skipping" rather than a build
+  break.
+- `serve/mod.rs` re-exports `ChannelSink`, `ChannelAdapter`, `InboundMessage`,
+  `ChannelReply` under `#[cfg(feature = "serve-channels")]`, alongside the
+  existing `ScheduleSink`/`Scheduler` exports.
+- Library-only embedders with no `serve*` feature pay nothing — the parser
+  (`ChannelSpec`) is always present (it is just data), but no transport,
+  no server deps, no adapter code compiles.
+
+---
+
+## 7. Test plan (TDD, no live network)
+
+Following the schedule layer's test style (sink counters, pre-cancelled tokens):
+
+1. **Sink invariant** — test `SessionChannelSink` with a record/replay
+   `LlmClient` injected via `SessionOptions.llm_client`, assert `deliver(msg)`
+   produces a session whose id is `channel:<name>:<conversation>` and that the
+   reply text equals the stubbed model text. Proves the message went through
+   `send` (history grew, verification ran), not a raw call.
+2. **Session reuse/isolation** — two `deliver`s with the same conversation reuse
+   one session (history length grows); different conversations get distinct
+   sessions.
+3. **Adapter normalization (offline)** — feed each adapter a canned wire payload
+   (a captured Slack event JSON, a Discord `MESSAGE_CREATE`, an HTTP body) and
+   assert the produced `InboundMessage` fields (conversation key, stripped text,
+   principal). No socket — the normalize function is pure and unit-testable.
+4. **Auth** — Slack signature verify accepts a correctly-signed fixture and
+   rejects a tampered body / stale timestamp; HTTP bearer compare rejects a bad
+   token.
+5. **Cancellation** — `adapter.serve(spec, sink, pre_cancelled_token)` returns
+   `Ok(())` promptly without binding (mirrors
+   `serve_builds_per_schedule_session_and_stops_on_cancel`).
+6. **Unknown kind** — `serve_agent_dir` with a `ChannelSpec { kind: "telegram" }`
+   logs and skips, does not error.
+
+No test leaves a socket bound or a temp file behind (CLAUDE.md TDD rule).
+
+---
+
+## 8. What this design deliberately does NOT do
+
+- No user-defined tools per channel (harness owns tools — the documented eve
+  divergence).
+- No bypass path: there is no API on `ChannelSink` other than `deliver`, and
+  `deliver` only calls `send`. A raw-model fast path is structurally impossible.
+- No new persistence model: durable rehydration rides the same stable-session-id
+  + `SessionStore` mechanism the daemon already plans for schedules.
+- No outbound-only "notification" channels — out of scope; this is the *inbound*
+  message seam. (A schedule that posts to Slack is the outbound story and already
+  works via a tool inside a scheduled turn.)
+- No per-message model override — model is the session/agent-dir concern, not a
+  transport concern.
+
+---
+
+## 9. Open design questions (flagged for review, not blocking the seam)
+
+1. Reply for multi-turn tool-using sessions can be slow; Slack/Discord want a
+   fast ACK + async reply (handled), but HTTP's synchronous reply could hit
+   client timeouts. Option: HTTP gains an optional async mode (`202 Accepted` +
+   callback URL). Deferred — sync is the correct reference default.
+2. Session eviction policy numbers (`max_live_sessions`, idle TTL) — needs a
+   real-workload default; the mechanism (LRU + `close()`) is settled, the
+   constants are not.
+3. Whether `InboundMessage` should carry attachments (Slack files, Discord
+   embeds) to use `send_with_attachments` instead of `send`. The seam allows it
+   (add a field + branch in the sink) but v1 is text-only for parity.

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "bytes",
  "cfb",
  "chrono",
+ "cron",
  "dirs",
  "flate2",
  "futures",
@@ -101,6 +102,7 @@ dependencies = [
  "napi-derive",
  "serde_json",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1318,6 +1320,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
 ]
 
 [[package]]

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -11,10 +11,11 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "3.6.2", path = "../../core", features = ["ahp", "s3"] }
+a3s-code-core = { version = "3.6.2", path = "../../core", features = ["ahp", "s3", "serve"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }
+tokio-util = "0.7"
 serde_json = "1.0"
 anyhow = "1.0"
 async-trait = "0.1"

--- a/sdk/node/generated.d.ts
+++ b/sdk/node/generated.d.ts
@@ -1234,6 +1234,50 @@ export declare class Agent {
    * deployments.
    */
   disconnectIdleMcp(idleThresholdMs: number): Promise<Array<string>>
+  /**
+   * Serve a filesystem-first agent directory's cron schedules until stopped.
+   *
+   * Loads the directory by convention (`instructions.md` required, optional
+   * `agent.acl`, `skills/`, `schedules/*.md`) and starts one durable session
+   * per enabled schedule (stable id `schedule:<name>`). Each schedule fires as
+   * a FULL harness turn (context, tool visibility, safety gate, verification),
+   * never a raw model call.
+   *
+   * Returns immediately with a {@link ServeHandle}; the daemon runs in the
+   * background until `handle.stop()` is called. The handle MUST be kept and
+   * stopped explicitly — dropping it does NOT cancel the daemon.
+   *
+   * ```js
+   * const handle = await agent.serveAgentDir('./my-agent', '/my-project');
+   * // ... later ...
+   * await handle.stop();
+   * ```
+   *
+   * @param dir - Path to the agent directory to serve (defines schedules/skills/prompt)
+   * @param workspace - Workspace directory each scheduled turn operates in
+   * @param options - Optional session overrides merged into every schedule session
+   *   (model, llmClient, sessionStore, …); `promptSlots`/`sessionId` set here are
+   *   NOT overridden so a host can pin them per schedule
+   */
+  serveAgentDir(dir: string, workspace: string, options?: SessionOptions | undefined | null): Promise<ServeHandle>
+}
+/**
+ * Lifetime handle for a running serve daemon (see {@link Agent.serveAgentDir}).
+ *
+ * The daemon keeps running until `stop()` is called. Dropping the handle does
+ * NOT cancel the daemon — call `stop()` explicitly for graceful shutdown.
+ */
+export declare class ServeHandle {
+  /**
+   * Request graceful shutdown of the serve daemon.
+   *
+   * Signals every per-schedule job to stop after its current fire. Idempotent:
+   * calling `stop()` more than once is a no-op. Resolves once the cancellation
+   * has been signalled.
+   */
+  stop(): Promise<void>
+  /** Whether `stop()` has been called on this handle. */
+  isStopped(): boolean
 }
 /** Workspace-bound session. All LLM and tool operations happen here. */
 export declare class Session {

--- a/sdk/node/index.js
+++ b/sdk/node/index.js
@@ -310,7 +310,7 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { formatVerificationSummary, EventStream, FileMemoryStore, FileSessionStore, MemorySessionStore, DefaultSecurityProvider, LocalWorkspaceBackend, S3WorkspaceBackend, StdioTransport, HttpTransport, WebSocketTransport, UnixSocketTransport, Agent, Session, builtinSkills, BrowserBackend } = nativeBinding
+const { formatVerificationSummary, EventStream, FileMemoryStore, FileSessionStore, MemorySessionStore, DefaultSecurityProvider, LocalWorkspaceBackend, S3WorkspaceBackend, StdioTransport, HttpTransport, WebSocketTransport, UnixSocketTransport, Agent, ServeHandle, Session, builtinSkills, BrowserBackend } = nativeBinding
 
 module.exports.formatVerificationSummary = formatVerificationSummary
 module.exports.EventStream = EventStream
@@ -325,6 +325,7 @@ module.exports.HttpTransport = HttpTransport
 module.exports.WebSocketTransport = WebSocketTransport
 module.exports.UnixSocketTransport = UnixSocketTransport
 module.exports.Agent = Agent
+module.exports.ServeHandle = ServeHandle
 module.exports.Session = Session
 module.exports.builtinSkills = builtinSkills
 module.exports.BrowserBackend = BrowserBackend

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -38,7 +38,7 @@
     "build": "napi build --platform --release --js index.js --dts generated.d.ts",
     "build:debug": "napi build --platform --js index.js --dts generated.d.ts",
     "prepublishOnly": "napi prepublish -t npm",
-    "test": "node test.mjs",
+    "test": "node test.mjs && node test_serve.mjs",
     "test:types": "tsc --noEmit --module nodenext --moduleResolution nodenext --target es2022 --strict --skipLibCheck test-types.ts",
     "test:helpers": "node test-helpers.mjs"
   },

--- a/sdk/node/src/lib.rs
+++ b/sdk/node/src/lib.rs
@@ -80,6 +80,8 @@ use a3s_code_core::verification::{
     VerificationCommand as RustVerificationCommand, VerificationReport as RustVerificationReport,
     VerificationStatus as RustVerificationStatus, VerificationSummary as RustVerificationSummary,
 };
+use a3s_code_core::config::AgentDir as RustAgentDir;
+use a3s_code_core::serve::serve_agent_dir as rust_serve_agent_dir;
 use a3s_code_core::{
     Agent as RustAgent, AgentEvent as RustAgentEvent, AgentResult as RustAgentResult,
     AgentSession as RustAgentSession, PlanningMode as RustPlanningMode,
@@ -87,6 +89,7 @@ use a3s_code_core::{
 };
 use napi::Either;
 use napi::Env;
+use tokio_util::sync::CancellationToken;
 
 // AHP Type Bindings
 mod ahp_types;
@@ -2998,6 +3001,95 @@ impl Agent {
         self.inner
             .disconnect_idle_mcp(idle_threshold_ms.max(0) as u64)
             .await
+    }
+
+    /// Serve a filesystem-first agent directory's cron schedules until stopped.
+    ///
+    /// Loads the directory by convention (`instructions.md` required, optional
+    /// `agent.acl`, `skills/`, `schedules/*.md`) and starts one durable session
+    /// per enabled schedule (stable id `schedule:<name>`). Each schedule fires as
+    /// a FULL harness turn (context, tool visibility, safety gate, verification),
+    /// never a raw model call.
+    ///
+    /// Returns immediately with a {@link ServeHandle}; the daemon runs in the
+    /// background until `handle.stop()` is called. The handle MUST be kept and
+    /// stopped explicitly — dropping it does NOT cancel the daemon.
+    ///
+    /// ```js
+    /// const handle = await agent.serveAgentDir('./my-agent', '/my-project');
+    /// // ... later ...
+    /// await handle.stop();
+    /// ```
+    ///
+    /// @param dir - Path to the agent directory to serve (defines schedules/skills/prompt)
+    /// @param workspace - Workspace directory each scheduled turn operates in
+    /// @param options - Optional session overrides merged into every schedule session
+    ///   (model, llmClient, sessionStore, …); `promptSlots`/`sessionId` set here are
+    ///   NOT overridden so a host can pin them per schedule
+    #[napi]
+    pub async fn serve_agent_dir(
+        &self,
+        dir: String,
+        workspace: String,
+        options: Option<SessionOptions>,
+    ) -> napi::Result<ServeHandle> {
+        let agent_dir = RustAgentDir::load(&dir)
+            .map_err(|e| napi::Error::from_reason(format!("Failed to load agent dir: {e}")))?;
+        let extra = js_session_options_to_rust(options)?;
+
+        // The daemon runs until cancelled; spawn it so control returns to JS
+        // immediately and the event loop is not blocked. The token, owned by the
+        // returned ServeHandle, drives graceful shutdown.
+        let cancel = CancellationToken::new();
+        let agent = self.inner.clone();
+        let handle_token = cancel.clone();
+
+        get_runtime().spawn(async move {
+            // Spawned task bodies are NOT panic-safe (a panic here is swallowed,
+            // never surfaced). `serve_agent_dir` returns Result and never panics
+            // by construction; a scheduling error is reported, not propagated.
+            if let Err(e) =
+                rust_serve_agent_dir(&agent, &agent_dir, workspace, Some(extra), cancel).await
+            {
+                eprintln!("a3s-code: serve_agent_dir daemon exited with error: {e}");
+            }
+        });
+
+        Ok(ServeHandle {
+            cancel: handle_token,
+        })
+    }
+}
+
+// ============================================================================
+// ServeHandle
+// ============================================================================
+
+/// Lifetime handle for a running serve daemon (see {@link Agent.serveAgentDir}).
+///
+/// The daemon keeps running until `stop()` is called. Dropping the handle does
+/// NOT cancel the daemon — call `stop()` explicitly for graceful shutdown.
+#[napi]
+pub struct ServeHandle {
+    cancel: CancellationToken,
+}
+
+#[napi]
+impl ServeHandle {
+    /// Request graceful shutdown of the serve daemon.
+    ///
+    /// Signals every per-schedule job to stop after its current fire. Idempotent:
+    /// calling `stop()` more than once is a no-op. Resolves once the cancellation
+    /// has been signalled.
+    #[napi]
+    pub async fn stop(&self) {
+        self.cancel.cancel();
+    }
+
+    /// Whether `stop()` has been called on this handle.
+    #[napi]
+    pub fn is_stopped(&self) -> bool {
+        self.cancel.is_cancelled()
     }
 }
 

--- a/sdk/node/test_serve.mjs
+++ b/sdk/node/test_serve.mjs
@@ -1,0 +1,102 @@
+// Serve layer (filesystem-first agents) — Node SDK tests.
+//
+// Verifies the napi serve binding added alongside the Rust serve daemon:
+//   agent.serveAgentDir(dir, workspace[, options]) -> ServeHandle
+//   handle.stop() / handle.isStopped()
+//
+// Unit (hermetic, inline ACL via temp file, no provider credentials): the
+// ServeHandle lifecycle and exports.
+// Integration (real provider, skipped without .a3s/config.acl): a real cron
+// schedule firing full harness turns through the daemon without aborting the
+// napi boundary (a panic in a sync #[napi] fn aborts the process), then a clean
+// stop.
+//
+// Run with: node test_serve.mjs   (or `npm test`)
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import mod from './index.js'
+
+const { Agent, ServeHandle } = mod
+
+const INLINE_CONFIG = `
+default_model = "anthropic/claude-sonnet-4-20250514"
+providers "anthropic" {
+  api_key = "test-key"
+  models "claude-sonnet-4-20250514" { name = "Claude Sonnet 4" }
+}
+`.trim()
+
+function mkConfigFile() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'a3s-node-serve-cfg-'))
+  const p = path.join(dir, 'agent.acl')
+  fs.writeFileSync(p, INLINE_CONFIG)
+  return p
+}
+
+function writeAgentDir({ withSchedule }) {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'a3s-node-serve-'))
+  fs.writeFileSync(path.join(base, 'instructions.md'), 'You are a terse test agent. Answer in one word.')
+  if (withSchedule) {
+    fs.mkdirSync(path.join(base, 'schedules'))
+    fs.writeFileSync(
+      path.join(base, 'schedules', 'tick.md'),
+      '---\ncron: "* * * * * *"\nname: tick\n---\nReply with exactly one word: PONG',
+    )
+  }
+  return base
+}
+
+function repoConfig() {
+  if (process.env.A3S_CONFIG_FILE && fs.existsSync(process.env.A3S_CONFIG_FILE)) {
+    return process.env.A3S_CONFIG_FILE
+  }
+  let dir = path.dirname(new URL(import.meta.url).pathname)
+  for (let i = 0; i < 8; i++) {
+    const cand = path.join(dir, '.a3s', 'config.acl')
+    if (fs.existsSync(cand)) return cand
+    dir = path.dirname(dir)
+  }
+  return null
+}
+
+// ── Unit (hermetic): exports + ServeHandle lifecycle ────────────────────────
+assert.equal(typeof ServeHandle, 'function', 'ServeHandle must be exported')
+assert.equal(typeof Agent.prototype.serveAgentDir, 'function', 'Agent.serveAgentDir must exist')
+
+{
+  const agent = await Agent.create(mkConfigFile())
+  const dir = writeAgentDir({ withSchedule: false })
+  const ws = fs.mkdtempSync(path.join(os.tmpdir(), 'a3s-node-serve-ws-'))
+  const handle = await agent.serveAgentDir(dir, ws)
+  assert.equal(handle.isStopped(), false, 'handle should not be stopped before stop()')
+  await handle.stop()
+  assert.equal(handle.isStopped(), true, 'stop() must set isStopped() true')
+  await handle.stop() // idempotent — must not throw
+  assert.equal(handle.isStopped(), true)
+  console.log('node sdk serve handle lifecycle ok')
+}
+
+// ── Integration (real provider, skipped without config) ─────────────────────
+{
+  const config = repoConfig()
+  if (!config) {
+    console.log('node sdk serve real-schedule SKIPPED (no .a3s/config.acl)')
+  } else {
+    const agent = await Agent.create(config)
+    const dir = writeAgentDir({ withSchedule: true })
+    const ws = fs.mkdtempSync(path.join(os.tmpdir(), 'a3s-node-serve-real-ws-'))
+    const handle = await agent.serveAgentDir(dir, ws)
+    assert.equal(handle.isStopped(), false)
+    // Let the every-second schedule fire real harness turns; surviving the
+    // window (no napi abort) is the integration assertion.
+    await new Promise((r) => setTimeout(r, 8000))
+    await handle.stop()
+    assert.equal(handle.isStopped(), true)
+    console.log('node sdk serve real-schedule ok (daemon fired real turns, stopped clean)')
+  }
+}
+
+console.log('all node serve tests passed')

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "bytes",
  "cfb",
  "chrono",
+ "cron",
  "dirs",
  "flate2",
  "futures",
@@ -100,6 +101,7 @@ dependencies = [
  "pyo3",
  "serde_json",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1308,6 +1310,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
 ]
 
 [[package]]

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -12,13 +12,14 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "3.6.2", path = "../../core", features = ["ahp", "s3"] }
+a3s-code-core = { version = "3.6.2", path = "../../core", features = ["ahp", "s3", "serve"] }
 pyo3 = "0.23"
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"
 anyhow = "1.0"
 async-trait = "0.1"
 num_cpus = "1.16"
+tokio-util = "0.7"
 
 [features]
 default = ["ahp"]

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -89,6 +89,10 @@ use std::sync::{
 };
 use tokio::runtime::Runtime;
 use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use a3s_code_core::config::AgentDir as RustAgentDir;
+use a3s_code_core::serve::serve_agent_dir as rust_serve_agent_dir;
 
 // ============================================================================
 // Utilities
@@ -1017,6 +1021,28 @@ impl PyEventStream {
 // Agent
 // ============================================================================
 
+/// Lifetime handle for a running serve daemon (see `Agent.serve_agent_dir`).
+///
+/// The daemon keeps running until `stop()` is called. Dropping the handle does
+/// NOT cancel the daemon — call `stop()` explicitly for graceful shutdown.
+#[pyclass(name = "ServeHandle")]
+struct PyServeHandle {
+    cancel: CancellationToken,
+}
+
+#[pymethods]
+impl PyServeHandle {
+    /// Request graceful shutdown of the serve daemon. Idempotent.
+    fn stop(&self) {
+        self.cancel.cancel();
+    }
+
+    /// Whether `stop()` has been called on this handle.
+    fn is_stopped(&self) -> bool {
+        self.cancel.is_cancelled()
+    }
+}
+
 /// AI coding agent. Create with `Agent.create()`, then call `agent.session()`.
 #[pyclass(name = "Agent")]
 struct PyAgent {
@@ -1040,6 +1066,59 @@ impl PyAgent {
 
         Ok(Self {
             inner: Arc::new(agent),
+        })
+    }
+
+    /// Serve a filesystem-first agent directory's cron schedules until stopped.
+    ///
+    /// Loads the directory by convention (`instructions.md` required, optional
+    /// `agent.acl`, `skills/`, `schedules/*.md`) and starts one durable session
+    /// per enabled schedule (stable id `schedule:<name>`). Each schedule fires as
+    /// a FULL harness turn (context, tool visibility, safety gate, verification),
+    /// never a raw model call.
+    ///
+    /// Returns immediately with a `ServeHandle`; the daemon runs in the
+    /// background until `handle.stop()` is called. Dropping the handle does NOT
+    /// cancel the daemon.
+    ///
+    /// Args:
+    ///     dir: Path to the agent directory to serve (schedules/skills/prompt)
+    ///     workspace: Workspace directory each scheduled turn operates in
+    ///     options: Optional SessionOptions merged into every schedule session
+    #[pyo3(signature = (dir, workspace, options=None))]
+    fn serve_agent_dir(
+        &self,
+        dir: String,
+        workspace: String,
+        options: Option<PySessionOptions>,
+    ) -> PyResult<PyServeHandle> {
+        let agent_dir = RustAgentDir::load(&dir)
+            .map_err(|e| PyRuntimeError::new_err(format!("Failed to load agent dir: {e}")))?;
+        let extra = match options {
+            Some(o) => Some(build_rust_session_options(o)?),
+            None => None,
+        };
+
+        // The daemon runs until cancelled; spawn it on the shared runtime so the
+        // call returns to Python immediately. The token, owned by the returned
+        // ServeHandle, drives graceful shutdown.
+        let cancel = CancellationToken::new();
+        let agent = self.inner.clone();
+        let handle_token = cancel.clone();
+
+        get_runtime().spawn(async move {
+            // serve_agent_dir returns Result and never panics by construction; a
+            // scheduling error is reported, not propagated (spawned task bodies
+            // are not panic-safe).
+            if let Err(e) =
+                rust_serve_agent_dir(&agent, &agent_dir, workspace, extra, cancel).await
+            {
+                eprintln!("a3s-code: serve_agent_dir daemon exited with error: {e}");
+            }
+        });
+
+        Ok(PyServeHandle {
+            cancel: handle_token,
         })
     }
 
@@ -6776,6 +6855,7 @@ fn a3s_code_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyAgentDefinition>()?;
     m.add_class::<PyAutoDelegationConfig>()?;
     m.add_class::<PySessionOptions>()?;
+    m.add_class::<PyServeHandle>()?;
     m.add_class::<PySessionQueueConfig>()?;
     m.add_class::<PySearchConfig>()?;
     m.add_class::<PySearchEngineConfig>()?;

--- a/sdk/python/tests/test_serve.py
+++ b/sdk/python/tests/test_serve.py
@@ -1,0 +1,112 @@
+"""Serve layer (filesystem-first agents) — Python SDK tests.
+
+Verifies the PyO3 serve binding added alongside the Rust serve daemon:
+- `agent.serve_agent_dir(dir, workspace[, options]) -> ServeHandle`
+- `handle.stop()` / `handle.is_stopped()`
+
+Unit (hermetic, inline ACL, no provider credentials): the ServeHandle lifecycle.
+Integration (real provider, skipped without `.a3s/config.acl`): a real cron
+schedule firing full harness turns through the serve daemon without aborting the
+FFI boundary, then a clean stop.
+
+Run with: python sdk/python/tests/test_serve.py
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import tempfile
+import time
+
+from a3s_code import Agent
+
+
+INLINE_CONFIG = """
+default_model = "anthropic/claude-sonnet-4-20250514"
+
+providers "anthropic" {
+  api_key = "test-key"
+  models "claude-sonnet-4-20250514" {
+    name = "Claude Sonnet 4"
+  }
+}
+""".strip()
+
+
+def _write_agent_dir(*, with_schedule: bool) -> str:
+    base = tempfile.mkdtemp(prefix="a3s-code-serve-")
+    pathlib.Path(base, "instructions.md").write_text(
+        "You are a terse test agent. Answer in one word."
+    )
+    if with_schedule:
+        sched = pathlib.Path(base, "schedules")
+        sched.mkdir()
+        (sched / "tick.md").write_text(
+            '---\ncron: "* * * * * *"\nname: tick\n---\nReply with exactly one word: PONG'
+        )
+    return base
+
+
+def test_serve_handle_lifecycle() -> None:
+    """Unit (hermetic): serving a dir with no schedules returns a ServeHandle
+    that reports not-stopped, and stop() is idempotent and reflected by
+    is_stopped(). No provider call is made."""
+    agent = Agent.create(INLINE_CONFIG)
+    agent_dir = _write_agent_dir(with_schedule=False)
+    workspace = tempfile.mkdtemp(prefix="a3s-code-serve-ws-")
+
+    handle = agent.serve_agent_dir(agent_dir, workspace)
+    assert handle.is_stopped() is False, "handle should not be stopped before stop()"
+
+    handle.stop()
+    assert handle.is_stopped() is True, "stop() must set is_stopped() to True"
+    handle.stop()  # idempotent — must not raise
+    assert handle.is_stopped() is True
+
+    print("python sdk serve handle lifecycle ok")
+
+
+def _repo_config() -> str | None:
+    env = os.environ.get("A3S_CONFIG_FILE")
+    if env and os.path.isfile(env):
+        return env
+    here = pathlib.Path(__file__).resolve()
+    for parent in here.parents:
+        cand = parent / ".a3s" / "config.acl"
+        if cand.is_file():
+            return str(cand)
+    return None
+
+
+def test_serve_real_schedule() -> None:
+    """Integration (real provider): serve a dir with an every-second schedule so
+    real harness turns fire through the daemon; the FFI boundary must survive the
+    real turns (a PyO3 panic would abort the process) and stop() must shut it
+    down. Skipped when no `.a3s/config.acl` is available."""
+    config = _repo_config()
+    if config is None:
+        print("python sdk serve real-schedule SKIPPED (no .a3s/config.acl)")
+        return
+
+    agent = Agent.create(config)
+    agent_dir = _write_agent_dir(with_schedule=True)
+    workspace = tempfile.mkdtemp(prefix="a3s-code-serve-real-ws-")
+
+    handle = agent.serve_agent_dir(agent_dir, workspace)
+    assert handle.is_stopped() is False
+    # Let the every-second schedule fire at least one real harness turn. The
+    # process surviving this window is the FFI integration assertion.
+    time.sleep(8)
+    handle.stop()
+    assert handle.is_stopped() is True
+    print("python sdk serve real-schedule ok (daemon fired real turns, stopped clean)")
+
+
+def main() -> None:
+    test_serve_handle_lifecycle()
+    test_serve_real_schedule()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a **filesystem-first agent layer** (vercel/eve parity, harness-respecting): a single directory defines a durable agent by convention, served by a cron daemon, with declarative `tools/`. Exposed in Rust + Python + TypeScript SDKs.

Built as a thin layer over existing primitives — no new runtime, no new prompt system. Gated behind the `serve` Cargo feature, so library-only embedders pay nothing.

## The agent directory

```
my-agent/
├── instructions.md   (required)  → SystemPromptSlots.role (a prompt SLOT, not a system-prompt override)
├── agent.acl         (optional)  → CodeConfig
├── skills/           (optional)  → skill_dirs
├── schedules/*.md    (optional)  → cron jobs (YAML frontmatter `cron:` + body prompt)
├── tools/*.md        (optional)  → kind: mcp → MCP servers registered into the session
└── channels/         (optional)  → parsed; adapters design-only
```

## Harness guardrails (the deliberate divergence from eve)

- `instructions.md` is a prompt **slot**, not a system-prompt override — BOUNDARIES / response-format / verification stay authoritative.
- Every schedule/tool runs through the **full harness**: a scheduled turn is `AgentSession::send` (context, tool visibility, safety gate, verification), never a raw model call.
- `tools/` *definition* comes from the directory, but *visibility + safety* stay harness-owned: an `mcp` spec is registered via the normal `add_mcp_server` path (`mcp__<server>__<tool>`, permission-gated), never as arbitrary host code.

## What's included

- **Core** (`serve` feature): `AgentDir::load` convention loader; `Scheduler`/`ScheduledJob` (5/6-field cron); `serve_agent_dir` daemon (one durable session per schedule, stable id `schedule:<name>`); `tools/` → `install_agent_dir_tools`.
- **SDKs**: `serveAgentDir`/`serve_agent_dir` + `ServeHandle` (`stop`/`isStopped`) in both Node (napi) and Python (PyO3). Node JS/TS glue regenerated so the API is reachable from JS/TS.
- **Docs**: user guide (`agent-dir.mdx`, in the monorepo root) + `tools/`→MCP and channels design docs.

## Tests

- **Rust**: 12 unit + 4 integration (2 hermetic + 2 real-LLM `#[ignore]`).
- **Python SDK**: `ServeHandle` lifecycle (unit) + real-LLM schedule fire (integration).
- **Node SDK**: same, wired into `npm test` (real part self-skips without config).

Real-LLM integration tests pass against `.a3s/config.acl` (glm5.1). All commits `cargo fmt`-clean.

## Out of scope (documented as next-increment)

- `channels/` adapters (HTTP/Slack/Discord) — design-only (`manual/CHANNELS_DESIGN.md`).
- Sandboxed-script `tools/` backend (`kind: script`) — design-only (`manual/AGENT_DIR_TOOLS_DESIGN.md`).
- User-facing `apps/docs` pages live in the a3s monorepo root (separate from this submodule PR).
