### PR TITLE
chore(release): v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.1.0] - Unreleased
+## [4.1.0] - 2026-06-23
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "a3s-acl 0.2.0",
  "a3s-ahp",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-core"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "a3s-acl 0.2.0",
  "a3s-ahp",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-node"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-node"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "4.0.0", path = "../../core", features = ["ahp", "s3", "serve"] }
+a3s-code-core = { version = "4.1.0", path = "../../core", features = ["ahp", "s3", "serve"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }

--- a/sdk/node/examples/package-lock.json
+++ b/sdk/node/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@a3s-lab/code",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -27,12 +27,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "4.0.0",
-        "@a3s-lab/code-linux-arm64-gnu": "4.0.0",
-        "@a3s-lab/code-linux-arm64-musl": "4.0.0",
-        "@a3s-lab/code-linux-x64-gnu": "4.0.0",
-        "@a3s-lab/code-linux-x64-musl": "4.0.0",
-        "@a3s-lab/code-win32-x64-msvc": "4.0.0"
+        "@a3s-lab/code-darwin-arm64": "4.1.0",
+        "@a3s-lab/code-linux-arm64-gnu": "4.1.0",
+        "@a3s-lab/code-linux-arm64-musl": "4.1.0",
+        "@a3s-lab/code-linux-x64-gnu": "4.1.0",
+        "@a3s-lab/code-linux-x64-musl": "4.1.0",
+        "@a3s-lab/code-win32-x64-msvc": "4.1.0"
       }
     },
     "node_modules/@a3s-lab/code": {

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/code",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/code",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -15,12 +15,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "4.0.0",
-        "@a3s-lab/code-linux-arm64-gnu": "4.0.0",
-        "@a3s-lab/code-linux-arm64-musl": "4.0.0",
-        "@a3s-lab/code-linux-x64-gnu": "4.0.0",
-        "@a3s-lab/code-linux-x64-musl": "4.0.0",
-        "@a3s-lab/code-win32-x64-msvc": "4.0.0"
+        "@a3s-lab/code-darwin-arm64": "4.1.0",
+        "@a3s-lab/code-linux-arm64-gnu": "4.1.0",
+        "@a3s-lab/code-linux-arm64-musl": "4.1.0",
+        "@a3s-lab/code-linux-x64-gnu": "4.1.0",
+        "@a3s-lab/code-linux-x64-musl": "4.1.0",
+        "@a3s-lab/code-win32-x64-msvc": "4.1.0"
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/code",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "A3S Code - Native Node.js bindings for the coding-agent runtime",
   "main": "index.js",
   "types": "index.d.ts",
@@ -43,11 +43,11 @@
     "test:helpers": "node test-helpers.mjs"
   },
   "optionalDependencies": {
-    "@a3s-lab/code-darwin-arm64": "4.0.0",
-    "@a3s-lab/code-linux-x64-gnu": "4.0.0",
-    "@a3s-lab/code-linux-x64-musl": "4.0.0",
-    "@a3s-lab/code-linux-arm64-gnu": "4.0.0",
-    "@a3s-lab/code-linux-arm64-musl": "4.0.0",
-    "@a3s-lab/code-win32-x64-msvc": "4.0.0"
+    "@a3s-lab/code-darwin-arm64": "4.1.0",
+    "@a3s-lab/code-linux-x64-gnu": "4.1.0",
+    "@a3s-lab/code-linux-x64-musl": "4.1.0",
+    "@a3s-lab/code-linux-arm64-gnu": "4.1.0",
+    "@a3s-lab/code-linux-arm64-musl": "4.1.0",
+    "@a3s-lab/code-win32-x64-msvc": "4.1.0"
   }
 }

--- a/sdk/python-bootstrap/pyproject.toml
+++ b/sdk/python-bootstrap/pyproject.toml
@@ -7,7 +7,7 @@ name = "a3s-code"
 # Keep in sync with crates/code core release. The bootstrap loader fetches
 # the matching native wheel from `https://github.com/AI45Lab/Code/releases/tag/v<version>`
 # at import time.
-version = "4.0.0"
+version = "4.1.0"
 description = "A3S Code Python SDK — pure-Python bootstrap that fetches the native wheel from GitHub Releases"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
+++ b/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 # Version is the bootstrap's own version, which equals the matching native
 # wheel version on GH Releases. Bumped by the release workflow.
-__version__ = "4.0.0"
+__version__ = "4.1.0"
 
 _DEFAULT_BASE_URL = "https://github.com/AI45Lab/Code/releases/download"
 _REQUEST_TIMEOUT_S = 120

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "a3s-acl 0.2.0",
  "a3s-ahp",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-py"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-py"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "4.0.0", path = "../../core", features = ["ahp", "s3", "serve"] }
+a3s-code-core = { version = "4.1.0", path = "../../core", features = ["ahp", "s3", "serve"] }
 pyo3 = "0.23"
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "a3s-code"
-version = "4.0.0"
+version = "4.1.0"
 description = "A3S Code - Native Python bindings for the coding-agent runtime"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Release of #72 (relax active-skill tool restrictions by default). Bumps all packages 4.0.0 → 4.1.0 + dates CHANGELOG. Verified: fmt, clippy, `cargo test -p a3s-code-core` (1784/0), node+python SDK compile, and `check_release_versions.sh 4.1.0`.