### PR TITLE
chore(release): v4.2.1 — fix Python SDK wheel build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.1] - 2026-06-23
+
+### Fixed
+
+- Python SDK wheel build (and therefore the PyPI + GitHub Release publish steps)
+  failed for 4.2.0: the `PyAutoDelegationConfig → AutoDelegationConfig`
+  conversion used a struct literal that omitted the `allow_manual_delegation`
+  field added to `AutoDelegationConfig`. The conversion now falls back to core
+  defaults for fields the Python SDK does not expose, so future core fields no
+  longer break the wheel build. (The crates.io and npm 4.2.0 artifacts were
+  unaffected; 4.2.1 completes the release across all channels.)
+
 ## [4.2.0] - 2026-06-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "4.2.0"
+version = "4.2.1"
 dependencies = [
  "a3s-acl 0.2.0",
  "a3s-ahp",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-core"
-version = "4.2.0"
+version = "4.2.1"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-node"
-version = "4.2.0"
+version = "4.2.1"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "4.2.0", path = "../../core", features = ["ahp", "s3", "serve"] }
+a3s-code-core = { version = "4.2.1", path = "../../core", features = ["ahp", "s3", "serve"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }

--- a/sdk/node/examples/package-lock.json
+++ b/sdk/node/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@a3s-lab/code",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -27,12 +27,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "4.2.0",
-        "@a3s-lab/code-linux-arm64-gnu": "4.2.0",
-        "@a3s-lab/code-linux-arm64-musl": "4.2.0",
-        "@a3s-lab/code-linux-x64-gnu": "4.2.0",
-        "@a3s-lab/code-linux-x64-musl": "4.2.0",
-        "@a3s-lab/code-win32-x64-msvc": "4.2.0"
+        "@a3s-lab/code-darwin-arm64": "4.2.1",
+        "@a3s-lab/code-linux-arm64-gnu": "4.2.1",
+        "@a3s-lab/code-linux-arm64-musl": "4.2.1",
+        "@a3s-lab/code-linux-x64-gnu": "4.2.1",
+        "@a3s-lab/code-linux-x64-musl": "4.2.1",
+        "@a3s-lab/code-win32-x64-msvc": "4.2.1"
       }
     },
     "node_modules/@a3s-lab/code": {

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/code",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/code",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -15,12 +15,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "4.2.0",
-        "@a3s-lab/code-linux-arm64-gnu": "4.2.0",
-        "@a3s-lab/code-linux-arm64-musl": "4.2.0",
-        "@a3s-lab/code-linux-x64-gnu": "4.2.0",
-        "@a3s-lab/code-linux-x64-musl": "4.2.0",
-        "@a3s-lab/code-win32-x64-msvc": "4.2.0"
+        "@a3s-lab/code-darwin-arm64": "4.2.1",
+        "@a3s-lab/code-linux-arm64-gnu": "4.2.1",
+        "@a3s-lab/code-linux-arm64-musl": "4.2.1",
+        "@a3s-lab/code-linux-x64-gnu": "4.2.1",
+        "@a3s-lab/code-linux-x64-musl": "4.2.1",
+        "@a3s-lab/code-win32-x64-msvc": "4.2.1"
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/code",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "A3S Code - Native Node.js bindings for the coding-agent runtime",
   "main": "index.js",
   "types": "index.d.ts",
@@ -43,11 +43,11 @@
     "test:helpers": "node test-helpers.mjs"
   },
   "optionalDependencies": {
-    "@a3s-lab/code-darwin-arm64": "4.2.0",
-    "@a3s-lab/code-linux-x64-gnu": "4.2.0",
-    "@a3s-lab/code-linux-x64-musl": "4.2.0",
-    "@a3s-lab/code-linux-arm64-gnu": "4.2.0",
-    "@a3s-lab/code-linux-arm64-musl": "4.2.0",
-    "@a3s-lab/code-win32-x64-msvc": "4.2.0"
+    "@a3s-lab/code-darwin-arm64": "4.2.1",
+    "@a3s-lab/code-linux-x64-gnu": "4.2.1",
+    "@a3s-lab/code-linux-x64-musl": "4.2.1",
+    "@a3s-lab/code-linux-arm64-gnu": "4.2.1",
+    "@a3s-lab/code-linux-arm64-musl": "4.2.1",
+    "@a3s-lab/code-win32-x64-msvc": "4.2.1"
   }
 }

--- a/sdk/python-bootstrap/pyproject.toml
+++ b/sdk/python-bootstrap/pyproject.toml
@@ -7,7 +7,7 @@ name = "a3s-code"
 # Keep in sync with crates/code core release. The bootstrap loader fetches
 # the matching native wheel from `https://github.com/AI45Lab/Code/releases/tag/v<version>`
 # at import time.
-version = "4.2.0"
+version = "4.2.1"
 description = "A3S Code Python SDK — pure-Python bootstrap that fetches the native wheel from GitHub Releases"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
+++ b/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 # Version is the bootstrap's own version, which equals the matching native
 # wheel version on GH Releases. Bumped by the release workflow.
-__version__ = "4.2.0"
+__version__ = "4.2.1"
 
 _DEFAULT_BASE_URL = "https://github.com/AI45Lab/Code/releases/download"
 _REQUEST_TIMEOUT_S = 120

--- a/sdk/python/Cargo.lock
+++ b/sdk/python/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "4.1.0"
+version = "4.2.1"
 dependencies = [
  "a3s-acl 0.2.0",
  "a3s-ahp",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-py"
-version = "4.1.0"
+version = "4.2.1"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-py"
-version = "4.2.0"
+version = "4.2.1"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "4.2.0", path = "../../core", features = ["ahp", "s3", "serve"] }
+a3s-code-core = { version = "4.2.1", path = "../../core", features = ["ahp", "s3", "serve"] }
 pyo3 = "0.23"
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "a3s-code"
-version = "4.2.0"
+version = "4.2.1"
 description = "A3S Code - Native Python bindings for the coding-agent runtime"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python/src/lib.rs
+++ b/sdk/python/src/lib.rs
@@ -4744,6 +4744,10 @@ impl From<PyAutoDelegationConfig> for a3s_code_core::AutoDelegationConfig {
             auto_parallel: config.auto_parallel,
             min_confidence: config.min_confidence.clamp(0.0, 1.0),
             max_tasks: config.max_tasks.max(1),
+            // Core fields not exposed by the Python SDK (e.g.
+            // `allow_manual_delegation`) take their core defaults, so adding a
+            // field to `AutoDelegationConfig` no longer breaks this wheel build.
+            ..Default::default()
         }
     }
 }


### PR DESCRIPTION
Completes the **4.2.0** release. crates.io + npm published fine, but the Python SDK wheel build failed (so PyPI + GitHub Release were skipped):

```
error[E0063]: missing field `allow_manual_delegation` in initializer of `AutoDelegationConfig`
💥 maturin failed
```

**Cause:** PR #76 added `allow_manual_delegation` to `AutoDelegationConfig`, but the Python SDK's `PyAutoDelegationConfig → AutoDelegationConfig` conversion uses a struct **literal** that didn't include it. Core CI never caught this — the SDKs are excluded from the core workspace and only built at release time (maturin). (The Node SDK was fine: it builds via `Default::default()` + field assignment.)

**Fix:** the Python conversion now uses `..Default::default()` for fields it doesn't expose, so future core fields can't break the wheel build. Verified the Python SDK compiles (`cargo build --manifest-path sdk/python/Cargo.toml`).

Version bumped **4.2.0 → 4.2.1** across the CI-enforced surface + CHANGELOG. Tagging `v4.2.1` re-runs the full release (crates.io + npm + **PyPI** + **GitHub Release**) to complete delivery across all channels.

Follow-up (not in this PR): add an SDK build step to core CI so SDK-breaking core changes are caught before release.