### PR TITLE
ci: type-check Node and Python SDKs on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,30 @@ jobs:
 
       # - name: Tests
       #   run: cargo test --workspace --lib
+
+  sdk-check:
+    name: SDK build check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup workspace context
+        run: bash .github/setup-workspace.sh
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      # The Node and Python SDKs are excluded from the core workspace and are
+      # otherwise only compiled at release time (napi / maturin). Type-check them
+      # here so a core change that breaks an SDK (e.g. a new struct field that an
+      # SDK constructs with a literal) fails on the PR instead of the release.
+      - name: Check Node SDK
+        run: cargo check --manifest-path sdk/node/Cargo.toml
+
+      - name: Check Python SDK
+        run: cargo check --manifest-path sdk/python/Cargo.toml


### PR DESCRIPTION
## Why
The Node and Python SDKs are **excluded from the core workspace** (`members = ["core"]`) and were only compiled at **release time** (napi / maturin). So a core change that breaks an SDK never showed up in CI.

That's exactly how v4.2.0 broke: PR #76 added `allow_manual_delegation` to `AutoDelegationConfig`, the Python SDK constructed that struct with a literal, and the missing field (`error[E0063]`) only failed the **release wheel build** — after crates.io + npm had already published. (Fixed in #80 / v4.2.1.)

## What
Adds an `SDK build check` job to `ci.yml` (runs on PRs + pushes to main) that `cargo check`s both SDK manifests:

```yaml
- run: cargo check --manifest-path sdk/node/Cargo.toml
- run: cargo check --manifest-path sdk/python/Cargo.toml
```

`cargo check` does full type/borrow checking — it would have caught the E0063 on the PR. Verified both commands locally (Rust + protoc only; no node/python interpreter setup needed for `check`). Mirrors the existing `check` job's setup.

This shifts SDK-breakage detection left: it now fails the PR instead of the release pipeline.