### PR TITLE
v4.2.6 — PTC supports parallel execution (delegation tools fan out from program scripts)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "4.2.5"
+version = "4.2.6"
 dependencies = [
  "a3s-acl 0.2.0",
  "a3s-ahp",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-core"
-version = "4.2.5"
+version = "4.2.6"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/core/src/tools/program_tool.rs
+++ b/core/src/tools/program_tool.rs
@@ -213,12 +213,9 @@ fn script_allowed_tools(args: &serde_json::Value, registry: &ToolRegistry) -> Ha
         .unwrap_or_else(|| registry.list().into_iter().collect());
 
     allowed.remove("program");
-    // Delegation tools can't run inside a PTC script: child agents need the
-    // multi-threaded session runtime, but the script executes on a nested
-    // single-thread runtime where they can't fan out. Force the model to call
-    // them directly instead of `ctx.tool("parallel_task", ...)`.
-    allowed.remove("task");
-    allowed.remove("parallel_task");
+    // `task`/`parallel_task` ARE allowed in PTC scripts now: host tool calls run
+    // on the outer multi-threaded runtime (see execute_host_tool_json), so
+    // `ctx.tool("parallel_task", …)` fans out child agents in parallel.
     allowed
 }
 
@@ -277,6 +274,9 @@ async fn run_quickjs_script(
         .max_output_bytes
         .unwrap_or(DEFAULT_SCRIPT_MAX_OUTPUT_BYTES);
     let executable_source = script_source_with_host_entrypoint(source)?;
+    // Captured on the outer multi-threaded runtime (we're async here, before the
+    // VM's nested single-thread runtime is built) so host tool calls fan out.
+    let outer = tokio::runtime::Handle::current();
     let state = Arc::new(Mutex::new(ScriptVmState {
         registry,
         ctx,
@@ -285,6 +285,7 @@ async fn run_quickjs_script(
         max_output_bytes,
         tool_calls: 0,
         records: Vec::new(),
+        outer,
     }));
 
     let vm_state = Arc::clone(&state);
@@ -407,6 +408,10 @@ struct ScriptVmState {
     max_output_bytes: usize,
     tool_calls: usize,
     records: Vec<ScriptCallRecord>,
+    /// Handle to the OUTER multi-threaded session runtime. The script VM runs on
+    /// a nested single-thread runtime; host tool calls are dispatched here so
+    /// delegation tools (`parallel_task`/`task`) can actually fan out children.
+    outer: tokio::runtime::Handle,
 }
 
 fn embedded_script_bootstrap(inputs_json: &str) -> String {
@@ -447,7 +452,7 @@ async fn execute_host_tool_json(
     let args = serde_json::from_str(&args_json).map_err(|err| {
         JsError::new_from_js_message("string", "object", format!("invalid tool args JSON: {err}"))
     })?;
-    let (registry, ctx, max_output_bytes) = {
+    let (registry, ctx, max_output_bytes, outer) = {
         let mut script = state.lock().await;
         if !script.allowed_tools.contains(&tool) {
             return Err(JsError::new_from_js_message(
@@ -468,12 +473,22 @@ async fn execute_host_tool_json(
             Arc::clone(&script.registry),
             script.ctx.clone(),
             script.max_output_bytes,
+            script.outer.clone(),
         )
     };
 
-    let result = registry
-        .execute_with_context(&tool, &args, &ctx)
+    // Run the tool on the OUTER multi-threaded runtime (not this nested
+    // single-thread VM runtime) so delegation tools can spawn child agents that
+    // actually run in parallel — `ctx.tool("parallel_task", …)` now fans out.
+    let tool_for_spawn = tool.clone();
+    let result = outer
+        .spawn(async move {
+            registry
+                .execute_with_context(&tool_for_spawn, &args, &ctx)
+                .await
+        })
         .await
+        .map_err(|err| JsError::new_from_js_message("tool", "spawn", err.to_string()))?
         .map_err(|err| JsError::new_from_js_message("tool", "result", err.to_string()))?;
     let mut output = result.output;
     if output.len() > max_output_bytes {
@@ -672,6 +687,22 @@ mod tests {
 
         let allowed = script_allowed_tools(&serde_json::json!({}), &registry);
 
+        assert!(allowed.contains("echo"));
+        assert!(!allowed.contains("program"));
+    }
+
+    #[test]
+    fn program_tool_allows_delegation_tools_in_scripts() {
+        // Delegation tools are allowed in PTC scripts again (host tool calls run
+        // on the outer multi-threaded runtime, so they fan out). Only `program`
+        // stays stripped (no nested PTC recursion).
+        let registry = ToolRegistry::new(PathBuf::from("/tmp"));
+        let args = serde_json::json!({
+            "allowed_tools": ["parallel_task", "task", "program", "echo"]
+        });
+        let allowed = script_allowed_tools(&args, &registry);
+        assert!(allowed.contains("parallel_task"));
+        assert!(allowed.contains("task"));
         assert!(allowed.contains("echo"));
         assert!(!allowed.contains("program"));
     }

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-node"
-version = "4.2.5"
+version = "4.2.6"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "4.2.5", path = "../../core", features = ["ahp", "s3", "serve"] }
+a3s-code-core = { version = "4.2.6", path = "../../core", features = ["ahp", "s3", "serve"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }

--- a/sdk/node/examples/package-lock.json
+++ b/sdk/node/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@a3s-lab/code",
-      "version": "4.2.5",
+      "version": "4.2.6",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -27,12 +27,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "4.2.5",
-        "@a3s-lab/code-linux-arm64-gnu": "4.2.5",
-        "@a3s-lab/code-linux-arm64-musl": "4.2.5",
-        "@a3s-lab/code-linux-x64-gnu": "4.2.5",
-        "@a3s-lab/code-linux-x64-musl": "4.2.5",
-        "@a3s-lab/code-win32-x64-msvc": "4.2.5"
+        "@a3s-lab/code-darwin-arm64": "4.2.6",
+        "@a3s-lab/code-linux-arm64-gnu": "4.2.6",
+        "@a3s-lab/code-linux-arm64-musl": "4.2.6",
+        "@a3s-lab/code-linux-x64-gnu": "4.2.6",
+        "@a3s-lab/code-linux-x64-musl": "4.2.6",
+        "@a3s-lab/code-win32-x64-msvc": "4.2.6"
       }
     },
     "node_modules/@a3s-lab/code": {

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/code",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/code",
-      "version": "4.2.5",
+      "version": "4.2.6",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -15,12 +15,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "4.2.5",
-        "@a3s-lab/code-linux-arm64-gnu": "4.2.5",
-        "@a3s-lab/code-linux-arm64-musl": "4.2.5",
-        "@a3s-lab/code-linux-x64-gnu": "4.2.5",
-        "@a3s-lab/code-linux-x64-musl": "4.2.5",
-        "@a3s-lab/code-win32-x64-msvc": "4.2.5"
+        "@a3s-lab/code-darwin-arm64": "4.2.6",
+        "@a3s-lab/code-linux-arm64-gnu": "4.2.6",
+        "@a3s-lab/code-linux-arm64-musl": "4.2.6",
+        "@a3s-lab/code-linux-x64-gnu": "4.2.6",
+        "@a3s-lab/code-linux-x64-musl": "4.2.6",
+        "@a3s-lab/code-win32-x64-msvc": "4.2.6"
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/code",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "description": "A3S Code - Native Node.js bindings for the coding-agent runtime",
   "main": "index.js",
   "types": "index.d.ts",
@@ -43,11 +43,11 @@
     "test:helpers": "node test-helpers.mjs"
   },
   "optionalDependencies": {
-    "@a3s-lab/code-darwin-arm64": "4.2.5",
-    "@a3s-lab/code-linux-x64-gnu": "4.2.5",
-    "@a3s-lab/code-linux-x64-musl": "4.2.5",
-    "@a3s-lab/code-linux-arm64-gnu": "4.2.5",
-    "@a3s-lab/code-linux-arm64-musl": "4.2.5",
-    "@a3s-lab/code-win32-x64-msvc": "4.2.5"
+    "@a3s-lab/code-darwin-arm64": "4.2.6",
+    "@a3s-lab/code-linux-x64-gnu": "4.2.6",
+    "@a3s-lab/code-linux-x64-musl": "4.2.6",
+    "@a3s-lab/code-linux-arm64-gnu": "4.2.6",
+    "@a3s-lab/code-linux-arm64-musl": "4.2.6",
+    "@a3s-lab/code-win32-x64-msvc": "4.2.6"
   }
 }

--- a/sdk/python-bootstrap/pyproject.toml
+++ b/sdk/python-bootstrap/pyproject.toml
@@ -7,7 +7,7 @@ name = "a3s-code"
 # Keep in sync with crates/code core release. The bootstrap loader fetches
 # the matching native wheel from `https://github.com/AI45Lab/Code/releases/tag/v<version>`
 # at import time.
-version = "4.2.5"
+version = "4.2.6"
 description = "A3S Code Python SDK — pure-Python bootstrap that fetches the native wheel from GitHub Releases"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
+++ b/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 # Version is the bootstrap's own version, which equals the matching native
 # wheel version on GH Releases. Bumped by the release workflow.
-__version__ = "4.2.5"
+__version__ = "4.2.6"
 
 _DEFAULT_BASE_URL = "https://github.com/AI45Lab/Code/releases/download"
 _REQUEST_TIMEOUT_S = 120

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-py"
-version = "4.2.5"
+version = "4.2.6"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "4.2.5", path = "../../core", features = ["ahp", "s3", "serve"] }
+a3s-code-core = { version = "4.2.6", path = "../../core", features = ["ahp", "s3", "serve"] }
 pyo3 = "0.23"
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "a3s-code"
-version = "4.2.5"
+version = "4.2.6"
 description = "A3S Code - Native Python bindings for the coding-agent runtime"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Makes `ctx.tool('parallel_task', …)` inside a `program`/PTC script actually fan out child agents in parallel — the missing piece for script-driven dynamic workflows.

**Root cause:** the PTC VM runs on a nested `new_current_thread` runtime (inside `spawn_blocking`), so `parallel_task`'s `tokio::spawn`ed child agent loops ran cooperatively on that single thread — no real parallelism. 4.2.3 worked around it by stripping `task`/`parallel_task` from PTC scripts.

**Fix:** `run_quickjs_script` captures the OUTER multi-threaded session runtime `Handle::current()`; `execute_host_tool_json` now `outer.spawn(...)`s the tool there, so a tool's child agents run on the multi-thread runtime and fan out. Re-allowed `task`/`parallel_task` in `script_allowed_tools`.

Test: `program_tool_allows_delegation_tools_in_scripts`; builds clean (Send-safe). Bumps to 4.2.6 (versions aligned). Unblocks the CLI's script-driven ultracode workflows.