### PR TITLE
v4.2.8 — retry transient network errors (not just HTTP status codes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "4.2.7"
+version = "4.2.8"
 dependencies = [
  "a3s-acl 0.2.0",
  "a3s-ahp",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-core"
-version = "4.2.7"
+version = "4.2.8"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"

--- a/core/src/llm/anthropic.rs
+++ b/core/src/llm/anthropic.rs
@@ -356,7 +356,23 @@ impl AnthropicClient {
                             match result {
                                 Ok(r) => r,
                                 Err(e) => {
-                                    return AttemptOutcome::Fatal(anyhow::anyhow!("HTTP request failed: {}", e));
+                                    // A transient network error (timeout, reset,
+                                    // mid-flight drop — common on throttled
+                                    // endpoints) carries no HTTP status. Retry it
+                                    // with backoff like 429/5xx instead of failing
+                                    // the turn; a real fatal error still bails.
+                                    return if crate::retry::is_transient_error(&e) {
+                                        AttemptOutcome::Retryable {
+                                            status: reqwest::StatusCode::SERVICE_UNAVAILABLE,
+                                            body: format!("network error: {e}"),
+                                            retry_after: None,
+                                        }
+                                    } else {
+                                        AttemptOutcome::Fatal(anyhow::anyhow!(
+                                            "HTTP request failed: {}",
+                                            e
+                                        ))
+                                    };
                                 }
                             }
                         }

--- a/core/src/llm/openai.rs
+++ b/core/src/llm/openai.rs
@@ -573,7 +573,23 @@ impl OpenAiClient {
                             match result {
                                 Ok(r) => r,
                                 Err(e) => {
-                                    return AttemptOutcome::Fatal(anyhow::anyhow!("HTTP request failed: {}", e));
+                                    // Transient network error (timeout, reset,
+                                    // mid-flight drop — common on throttled
+                                    // endpoints): retry with backoff like 429/5xx
+                                    // instead of failing the turn. GLM and other
+                                    // OpenAI-compatible endpoints hit this most.
+                                    return if crate::retry::is_transient_error(&e) {
+                                        AttemptOutcome::Retryable {
+                                            status: reqwest::StatusCode::SERVICE_UNAVAILABLE,
+                                            body: format!("network error: {e}"),
+                                            retry_after: None,
+                                        }
+                                    } else {
+                                        AttemptOutcome::Fatal(anyhow::anyhow!(
+                                            "HTTP request failed: {}",
+                                            e
+                                        ))
+                                    };
                                 }
                             }
                         }

--- a/core/src/retry.rs
+++ b/core/src/retry.rs
@@ -183,11 +183,58 @@ where
     )
 }
 
+/// Heuristic: is this a transient *network* error worth retrying — a timeout,
+/// connection reset/refused/closed, broken pipe, DNS failure, or a request that
+/// dropped mid-flight? These carry no HTTP status (so `is_retryable_status`
+/// can't see them), yet Claude Code retries them just like 429/5xx. We only have
+/// the error's rendered text (a `CodeError`/`anyhow::Error` chain) to classify.
+pub fn is_transient_error<E: std::fmt::Display>(e: &E) -> bool {
+    let m = e.to_string().to_lowercase();
+    [
+        "timed out",
+        "timeout",
+        "connection reset",
+        "connection refused",
+        "connection closed",
+        "connection aborted",
+        "connection error",
+        "broken pipe",
+        "reset by peer",
+        "error sending request",
+        "incomplete message",
+        "unexpected eof",
+        "dns error",
+        "unreachable",
+        "tls handshake",
+        "request error",
+        "body error",
+        "decoding response",
+        "channel closed",
+        "stream closed",
+    ]
+    .iter()
+    .any(|p| m.contains(p))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
+
+    #[test]
+    fn transient_error_classification() {
+        let t = |s: &str| is_transient_error(&anyhow::anyhow!("{s}"));
+        // Transient network errors → retry.
+        assert!(t("error sending request for url: operation timed out"));
+        assert!(t("connection reset by peer"));
+        assert!(t("LLM error: connection closed before message completed"));
+        assert!(t("tls handshake eof"));
+        // Real application errors → do NOT retry.
+        assert!(!t("invalid api key"));
+        assert!(!t("model not found"));
+        assert!(!t("context length exceeded"));
+    }
 
     // ========================================================================
     // RetryConfig unit tests

--- a/sdk/node/Cargo.lock
+++ b/sdk/node/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-core"
-version = "4.2.6"
+version = "4.2.7"
 dependencies = [
  "a3s-acl 0.2.0",
  "a3s-ahp",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "a3s-code-node"
-version = "4.2.6"
+version = "4.2.7"
 dependencies = [
  "a3s-code-core",
  "anyhow",

--- a/sdk/node/Cargo.toml
+++ b/sdk/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-node"
-version = "4.2.7"
+version = "4.2.8"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -11,7 +11,7 @@ description = "A3S Code Node.js bindings - Native addon via napi-rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "4.2.7", path = "../../core", features = ["ahp", "s3", "serve"] }
+a3s-code-core = { version = "4.2.8", path = "../../core", features = ["ahp", "s3", "serve"] }
 napi = { version = "2", features = ["async", "napi6", "serde-json"] }
 napi-derive = "2"
 tokio = { version = "1.35", features = ["full"] }

--- a/sdk/node/examples/package-lock.json
+++ b/sdk/node/examples/package-lock.json
@@ -18,7 +18,7 @@
     },
     "..": {
       "name": "@a3s-lab/code",
-      "version": "4.2.7",
+      "version": "4.2.8",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -27,12 +27,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "4.2.7",
-        "@a3s-lab/code-linux-arm64-gnu": "4.2.7",
-        "@a3s-lab/code-linux-arm64-musl": "4.2.7",
-        "@a3s-lab/code-linux-x64-gnu": "4.2.7",
-        "@a3s-lab/code-linux-x64-musl": "4.2.7",
-        "@a3s-lab/code-win32-x64-msvc": "4.2.7"
+        "@a3s-lab/code-darwin-arm64": "4.2.8",
+        "@a3s-lab/code-linux-arm64-gnu": "4.2.8",
+        "@a3s-lab/code-linux-arm64-musl": "4.2.8",
+        "@a3s-lab/code-linux-x64-gnu": "4.2.8",
+        "@a3s-lab/code-linux-x64-musl": "4.2.8",
+        "@a3s-lab/code-win32-x64-msvc": "4.2.8"
       }
     },
     "node_modules/@a3s-lab/code": {

--- a/sdk/node/package-lock.json
+++ b/sdk/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@a3s-lab/code",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@a3s-lab/code",
-      "version": "4.2.7",
+      "version": "4.2.8",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2",
@@ -15,12 +15,12 @@
         "typescript": "^5.9.3"
       },
       "optionalDependencies": {
-        "@a3s-lab/code-darwin-arm64": "4.2.7",
-        "@a3s-lab/code-linux-arm64-gnu": "4.2.7",
-        "@a3s-lab/code-linux-arm64-musl": "4.2.7",
-        "@a3s-lab/code-linux-x64-gnu": "4.2.7",
-        "@a3s-lab/code-linux-x64-musl": "4.2.7",
-        "@a3s-lab/code-win32-x64-msvc": "4.2.7"
+        "@a3s-lab/code-darwin-arm64": "4.2.8",
+        "@a3s-lab/code-linux-arm64-gnu": "4.2.8",
+        "@a3s-lab/code-linux-arm64-musl": "4.2.8",
+        "@a3s-lab/code-linux-x64-gnu": "4.2.8",
+        "@a3s-lab/code-linux-x64-musl": "4.2.8",
+        "@a3s-lab/code-win32-x64-msvc": "4.2.8"
       }
     },
     "node_modules/@a3s-lab/code-darwin-arm64": {

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a3s-lab/code",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "description": "A3S Code - Native Node.js bindings for the coding-agent runtime",
   "main": "index.js",
   "types": "index.d.ts",
@@ -43,11 +43,11 @@
     "test:helpers": "node test-helpers.mjs"
   },
   "optionalDependencies": {
-    "@a3s-lab/code-darwin-arm64": "4.2.7",
-    "@a3s-lab/code-linux-x64-gnu": "4.2.7",
-    "@a3s-lab/code-linux-x64-musl": "4.2.7",
-    "@a3s-lab/code-linux-arm64-gnu": "4.2.7",
-    "@a3s-lab/code-linux-arm64-musl": "4.2.7",
-    "@a3s-lab/code-win32-x64-msvc": "4.2.7"
+    "@a3s-lab/code-darwin-arm64": "4.2.8",
+    "@a3s-lab/code-linux-x64-gnu": "4.2.8",
+    "@a3s-lab/code-linux-x64-musl": "4.2.8",
+    "@a3s-lab/code-linux-arm64-gnu": "4.2.8",
+    "@a3s-lab/code-linux-arm64-musl": "4.2.8",
+    "@a3s-lab/code-win32-x64-msvc": "4.2.8"
   }
 }

--- a/sdk/node/ptc_soak.mjs
+++ b/sdk/node/ptc_soak.mjs
@@ -25,13 +25,15 @@ function script(n) {
   return JSON.stringify(res);
 }`;
 }
+// NO explicit limits → exercises the DEFAULT script timeout. With 50-word
+// subtasks (each >30s on this model), 4.2.6's 30s default would time out; 4.2.7
+// gives delegation-capable scripts 10min, so it should complete.
 const promptFor = (n) =>
   'Call the `program` tool exactly once, now, with these arguments, then stop.\n\nArguments:\n' +
   JSON.stringify({
     type: 'script',
     language: 'javascript',
     source: script(n),
-    limits: { timeoutMs: 180000, maxToolCalls: 20 },
   });
 
 const agent = await Agent.create(CONFIG);

--- a/sdk/python-bootstrap/pyproject.toml
+++ b/sdk/python-bootstrap/pyproject.toml
@@ -7,7 +7,7 @@ name = "a3s-code"
 # Keep in sync with crates/code core release. The bootstrap loader fetches
 # the matching native wheel from `https://github.com/AI45Lab/Code/releases/tag/v<version>`
 # at import time.
-version = "4.2.7"
+version = "4.2.8"
 description = "A3S Code Python SDK — pure-Python bootstrap that fetches the native wheel from GitHub Releases"
 readme = "README.md"
 license = {text = "MIT"}

--- a/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
+++ b/sdk/python-bootstrap/src/a3s_code/_bootstrap.py
@@ -31,7 +31,7 @@ from typing import Optional
 
 # Version is the bootstrap's own version, which equals the matching native
 # wheel version on GH Releases. Bumped by the release workflow.
-__version__ = "4.2.7"
+__version__ = "4.2.8"
 
 _DEFAULT_BASE_URL = "https://github.com/AI45Lab/Code/releases/download"
 _REQUEST_TIMEOUT_S = 120

--- a/sdk/python/Cargo.toml
+++ b/sdk/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a3s-code-py"
-version = "4.2.7"
+version = "4.2.8"
 edition = "2021"
 authors = ["A3S Lab Team"]
 license = "MIT"
@@ -12,7 +12,7 @@ name = "a3s_code"
 crate-type = ["cdylib"]
 
 [dependencies]
-a3s-code-core = { version = "4.2.7", path = "../../core", features = ["ahp", "s3", "serve"] }
+a3s-code-core = { version = "4.2.8", path = "../../core", features = ["ahp", "s3", "serve"] }
 pyo3 = "0.23"
 tokio = { version = "1.35", features = ["full"] }
 serde_json = "1.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "a3s-code"
-version = "4.2.7"
+version = "4.2.8"
 description = "A3S Code - Native Python bindings for the coding-agent runtime"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
The LLM retry path only retried HTTP statuses (429/500/502/503/529). A bare **network error** — timeout, connection reset, mid-flight drop, common on throttled endpoints like GLM — was classified `Fatal` and failed the turn with no retry.

Adds `retry::is_transient_error` and, in the streaming request path (anthropic + openai-compatible, which covers GLM), classifies transient network errors as `Retryable` (synthetic 503) so they back off + retry like Claude Code. Genuine errors (bad key, model-not-found, context-length) still bail immediately. Unit-tested; 34 retry tests pass. Bumps 4.2.8.